### PR TITLE
Implementation of rule 2B

### DIFF
--- a/src/accessible_name.ts
+++ b/src/accessible_name.ts
@@ -1,23 +1,4 @@
-import {Context} from './lib/context';
-import {rule2A} from './lib/rule2A';
-
-/**
- * @param currentNode - The node whose text alternative will be calculated
- * @param  context - Additional information relevant to the text alternative
- *     computation for node
- * @return - The text alternative for node
- */
-function computeTextAlternative(currentNode: Node, context: Context): string {
-  let result: string|null = '';
-
-  result = rule2A(currentNode, context);
-  if (result !== null) {
-    return result;
-  }
-
-  // If no result is found, the empty string is the text alternative
-  return '';
-}
+import {computeTextAlternative} from './lib/compute_text_alternative';
 
 /**
  * Main exported function for the library. Initialises traversal with an empty

--- a/src/lib/compute_text_alternative.ts
+++ b/src/lib/compute_text_alternative.ts
@@ -1,0 +1,29 @@
+import {Context} from './context';
+import {rule2A} from './rule2A';
+import {rule2B} from './rule2B';
+
+/**
+ * @param currentNode - The node whose text alternative will be calculated
+ * @param  context - Additional information relevant to the text alternative
+ *     computation for node
+ * @return - The text alternative for node
+ */
+export function computeTextAlternative(
+  currentNode: Node,
+  context: Context
+): string {
+  let result: string | null = '';
+
+  result = rule2A(currentNode, context);
+  if (result !== null) {
+    return result;
+  }
+
+  result = rule2B(currentNode, context);
+  if (result !== null) {
+    return result;
+  }
+
+  // If no result is found, the empty string is the text alternative
+  return '';
+}

--- a/src/lib/rule2A.ts
+++ b/src/lib/rule2A.ts
@@ -34,8 +34,10 @@ function isHidden(node: Node): boolean {
  */
 function rule2ACondition(node: Node, context: Context): boolean {
   return (
-      isHidden(node) && !context.ariaLabelledbyReference &&
-      !context.labelReference);
+    isHidden(node) &&
+    !context.ariaLabelledbyReference &&
+    !context.labelReference
+  );
 }
 
 /**
@@ -47,7 +49,7 @@ function rule2ACondition(node: Node, context: Context): boolean {
  * null is returned otherwise, indicating that the condition of this rule was
  * not satisfied.
  */
-export function rule2A(node: Node, context: Context): string|null {
+export function rule2A(node: Node, context: Context): string | null {
   let result = null;
   if (rule2ACondition(node, context)) {
     result = '';

--- a/src/lib/rule2B.ts
+++ b/src/lib/rule2B.ts
@@ -1,0 +1,52 @@
+import {computeTextAlternative} from './compute_text_alternative';
+import {Context} from './context';
+
+/**
+ * Gets the valid idrefs listed in the aria-labelledby attribute of elem.
+ * @param elem - the element whose valid aria-labelledby idrefs are being
+ * calculated
+ * @return - a list of idref strings for whom elements exist in the document.
+ */
+function getValidAriaLabelledbyIdrefs(elem: HTMLElement): string[] {
+  let idrefs: string[] = [];
+  const idrefStr = elem.getAttribute('aria-labelledby');
+  if (idrefStr) {
+    idrefs = idrefStr.split(' ');
+  }
+  // A valid idref is considered here to mean an idref that identifies an
+  // existing element in the document.
+  const validIdrefs = idrefs.filter(idref => !!document.getElementById(idref));
+  return validIdrefs;
+}
+
+/**
+ * Implementation of rule 2B
+ * @param node - node whose text alternative is being computed
+ * @param context - Additional information relevant to the text alternative
+ * computation for node
+ * @return - The text alternative string is returned if condition is true,
+ * null is returned otherwise, indicating that the condition of this rule was
+ * not satisfied.
+ */
+export function rule2B(node: Node, context: Context): string | null {
+  let result = null;
+  if (node instanceof HTMLElement) {
+    const validIdrefs = getValidAriaLabelledbyIdrefs(node);
+    const rule2BCondition =
+      validIdrefs.length > 0 && !context.ariaLabelledbyReference;
+    if (rule2BCondition) {
+      let accumulatedText = '';
+      validIdrefs.forEach(idref => {
+        const node = document.getElementById(idref);
+        if (node) {
+          // ariaLabelledbyReference property in context indicates that
+          // node is part of an aria-labelledby traversal
+          accumulatedText +=
+            computeTextAlternative(node, {ariaLabelledbyReference: true}) + ' ';
+        }
+      });
+      result = accumulatedText.trim();
+    }
+  }
+  return result;
+}

--- a/src/lib/rule2B.ts
+++ b/src/lib/rule2B.ts
@@ -9,17 +9,15 @@ import {Context} from './context';
  * by elem's aria-labelledby
  */
 function resolveValidAriaLabelledbyIdrefs(elem: HTMLElement): HTMLElement[] {
-  // Get a list of idref strings
   const idrefs = elem.getAttribute('aria-labelledby')?.split(' ') ?? [];
-  // Any idref that points to an element that exists in the document
-  // is considered valid here.
+
   const validElems: HTMLElement[] = [];
-  idrefs.forEach(idref => {
-    const elem = document.getElementById(idref);
+  for (const id of idrefs) {
+    const elem = document.getElementById(id);
     if (elem) {
       validElems.push(elem);
     }
-  });
+  }
   return validElems;
 }
 
@@ -37,22 +35,19 @@ export function rule2B(node: Node, context: Context): string | null {
     return null;
   }
 
-  // Check if node is part of an aria-labelledby traversal
   if (context.ariaLabelledbyReference) {
     return null;
   }
 
-  // Check that aria-labelledby contains at least one valid idref
   const labelElems = resolveValidAriaLabelledbyIdrefs(node);
   if (labelElems.length === 0) {
     return null;
   }
 
-  // Node text alternative = concatenate the text alternative for each labelElem.
   return labelElems
     .map(labelElem =>
       computeTextAlternative(labelElem, {ariaLabelledbyReference: true})
     )
     .join(' ')
-    .trim(); // (styles by gts - I swear I'm not responsible)
+    .trim();
 }

--- a/src/lib/rule2B_test.ts
+++ b/src/lib/rule2B_test.ts
@@ -1,0 +1,56 @@
+import {html, render} from 'lit-html';
+import {rule2B} from './rule2B';
+
+describe('The function for rule 2B', () => {
+  let container: HTMLElement;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('returns null if the element has no aria-labelledby attribute', () => {
+    render(html`<div id="foo">Hello</div>`, container);
+    const elem = document.getElementById('foo');
+    expect(rule2B(elem!, {})).toBe(null);
+  });
+
+  it('returns null if the element has no valid aria-labelledby idrefs', () => {
+    render(html`<div id="foo" aria-labelledby="bar">Hello</div>`, container);
+    const elem = document.getElementById('foo');
+    expect(rule2B(elem!, {})).toBe(null);
+  });
+
+  it('returns concatenation of text alternatives of idreffed elements', () => {
+      render(
+        html`
+      <div id="foo" aria-labelledby="bar baz">Hello</div>
+      <div id="bar"></div>
+      <div id="baz"></div>
+    `,
+        container);
+    const elem = document.getElementById('foo');
+    expect(rule2B(elem!, {})).toBe('');
+  });
+
+  it('returns null if the node is already part of an aria-labelledby traversal',
+    () => {
+        render(
+          html`
+        <div id="foo" aria-labelledby="bar">Hello</div>
+        <div id="bar"></div>
+      `,
+          container);
+      const elem = document.getElementById('foo');
+      expect(rule2B(elem!, {ariaLabelledbyReference: true})).toBe(null);
+    });
+
+  /*
+   * Many more tests needed here but can't be verified yet due to lack
+   * of other rules, (i.e 2F, 2G) along with the fact that the default
+   * acc name is the empty string.
+   */
+});

--- a/src/lib/rule2B_test.ts
+++ b/src/lib/rule2B_test.ts
@@ -49,8 +49,6 @@ describe('The function for rule 2B', () => {
     });
 
   /*
-   * Many more tests needed here but can't be verified yet due to lack
-   * of other rules, (i.e 2F, 2G) along with the fact that the default
-   * acc name is the empty string.
+   * TODO: Add tests to check aria-labelledby traversal (using rules 2F, 2G)
    */
 });


### PR DESCRIPTION
- Added rule2B.ts. Uses helper function to get 'valid' idrefs in aria-labelledby attribute. Uses context to mark node as being part of an aria-labelledby traversal.
- Put computeTextAlternative in its own file so that getAccessibleName is the only export from the main ts file (not sure if this is necessary but seems to make sense).
- Added some tests for rule 2B to rule2B_test.ts although more will certainly need to be added. At present some tests aren't possible without other rules implemented, since 'computeTextAlternative' is called from within rule2B.