### PR TITLE
Implementation for rules 2C, 2E

### DIFF
--- a/src/lib/compute_text_alternative.ts
+++ b/src/lib/compute_text_alternative.ts
@@ -1,6 +1,8 @@
 import {Context, getDefaultContext} from './context';
 import {rule2A} from './rule2A';
 import {rule2B} from './rule2B';
+import {rule2C} from './rule2C';
+import {rule2E} from './rule2E';
 import {rule2F} from './rule2F';
 import {rule2G} from './rule2G';
 
@@ -22,6 +24,16 @@ export function computeTextAlternative(
   }
 
   result = rule2B(node, context);
+  if (result !== null) {
+    return result;
+  }
+
+  result = rule2C(node, context);
+  if (result !== null) {
+    return result;
+  }
+
+  result = rule2E(node, context);
   if (result !== null) {
     return result;
   }

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -45,11 +45,11 @@ describe('The computeTextAlternative function', () => {
   it('prefers input value to aria-label for embedded controls', () => {
     render(
       html`
-        <button id="foo">
+        <div id="foo" role="link">
           Say hello
           <input aria-label="100" type="range" value="5" />
           times
-        </button>
+        </div>
       `,
       container
     );

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -41,4 +41,19 @@ describe('The computeTextAlternative function', () => {
     const elem = document.getElementById('foo');
     expect(computeTextAlternative(elem!)).toBe('Hello world');
   });
+
+  it('prefers input value to aria-label for embedded controls', () => {
+    render(
+      html`
+        <button id="foo">
+          Say hello
+          <input aria-label="100" type="range" value="5" />
+          times
+        </button>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(computeTextAlternative(elem!)).toBe('Say hello 5 times');
+  });
 });

--- a/src/lib/rule2A.ts
+++ b/src/lib/rule2A.ts
@@ -13,9 +13,11 @@ function isHidden(node: Node, context: Context): boolean {
   }
 
   // #SPEC_ASSUMPTION (A.3) : options shouldn't be hidden
-  if (node instanceof HTMLOptionElement &&
+  if (
+    node instanceof HTMLOptionElement &&
     node.closest('select') !== null &&
-    context.inherited.partOfName) {
+    context.inherited.partOfName
+  ) {
     return false;
   }
 

--- a/src/lib/rule2A.ts
+++ b/src/lib/rule2A.ts
@@ -13,9 +13,9 @@ function isHidden(node: Node, context: Context): boolean {
   }
 
   // #SPEC_ASSUMPTION (A.3) : options shouldn't be hidden
-  const isOption = node instanceof HTMLOptionElement;
-  const isInsideSelect = node.closest('select') !== null;
-  if (isOption && isInsideSelect && context.inherited.partOfName) {
+  if (node instanceof HTMLOptionElement &&
+    node.closest('select') !== null &&
+    context.inherited.partOfName) {
     return false;
   }
 

--- a/src/lib/rule2A.ts
+++ b/src/lib/rule2A.ts
@@ -7,8 +7,15 @@ import {Context, getDefaultContext} from './context';
  * @return - whether or not the node is considered hidden
  */
 // #SPEC_ASSUMPTION (A.2) : definition of 'hidden'
-function isHidden(node: Node): boolean {
+function isHidden(node: Node, context: Context): boolean {
   if (!(node instanceof HTMLElement)) {
+    return false;
+  }
+
+  // #SPEC_ASSUMPTION (A.3) : options shouldn't be hidden
+  const isOption = node instanceof HTMLOptionElement;
+  const isInsideSelect = node.closest('select') !== null;
+  if (isOption && isInsideSelect && context.inherited.partOfName) {
     return false;
   }
 
@@ -35,7 +42,7 @@ function isHidden(node: Node): boolean {
  */
 function rule2ACondition(node: Node, context: Context): boolean {
   // #SPEC_ASSUMPTION (A.1) : definition of 'directly referenced'
-  return isHidden(node) && !context.directLabelReference;
+  return isHidden(node, context) && !context.directLabelReference;
 }
 
 /**

--- a/src/lib/rule2A.ts
+++ b/src/lib/rule2A.ts
@@ -58,7 +58,7 @@ function rule2ACondition(node: Node, context: Context): boolean {
  */
 export function rule2A(
   node: Node,
-  context: Context = getDefaultContext()
+  context = getDefaultContext()
 ): string | null {
   let result = null;
   if (rule2ACondition(node, context)) {

--- a/src/lib/rule2B.ts
+++ b/src/lib/rule2B.ts
@@ -1,5 +1,5 @@
 import {computeTextAlternative} from './compute_text_alternative';
-import {Context, getDefaultContext} from './context';
+import {getDefaultContext} from './context';
 
 /**
  * Get any HTMLElement referenced in the aria-labelledby attribute
@@ -32,7 +32,7 @@ function resolveValidAriaLabelledbyIdrefs(elem: HTMLElement): HTMLElement[] {
  */
 export function rule2B(
   node: Node,
-  context: Context = getDefaultContext()
+  context = getDefaultContext()
 ): string | null {
   if (!(node instanceof HTMLElement)) {
     return null;

--- a/src/lib/rule2C.ts
+++ b/src/lib/rule2C.ts
@@ -1,0 +1,35 @@
+import {Context, getDefaultContext} from './context';
+import {rule2E} from './rule2E';
+
+/**
+ * Implementation for rule 2C
+ * @param node - node whose text alternative is being computed
+ * @param context - information relevant to the computation of node's text alternative
+ * @return text alternative for 'node' if rule 2C accepts 'node', null otherwise.
+ */
+export function rule2C(
+  node: Node,
+  context: Context = getDefaultContext()
+): string | null {
+  if (!(node instanceof HTMLElement)) {
+    return null;
+  }
+
+  const ariaLabel = node.getAttribute('aria-label') ?? '';
+  if (ariaLabel.trim() === '') {
+    return null;
+  }
+
+  // #SPEC_ASSUMPTION (C.1) : 'part of name' implies 'traversal
+  // due to recursion'.
+  if (context.inherited.partOfName) {
+    // 'rule2EResult !== null' indicates that 'node' is an embedded
+    // control as defined in step 2E.
+    const rule2EResult = rule2E(node, {inherited: context.inherited});
+    if (rule2EResult !== null) {
+      return rule2EResult;
+    }
+  }
+
+  return ariaLabel;
+}

--- a/src/lib/rule2C.ts
+++ b/src/lib/rule2C.ts
@@ -1,4 +1,4 @@
-import {Context, getDefaultContext} from './context';
+import {getDefaultContext} from './context';
 import {rule2E} from './rule2E';
 
 /**
@@ -9,7 +9,7 @@ import {rule2E} from './rule2E';
  */
 export function rule2C(
   node: Node,
-  context: Context = getDefaultContext()
+  context = getDefaultContext()
 ): string | null {
   if (!(node instanceof HTMLElement)) {
     return null;

--- a/src/lib/rule2C_test.ts
+++ b/src/lib/rule2C_test.ts
@@ -21,6 +21,7 @@ describe('The function for rule 2C', () => {
 
   it('returns null if node is not HTMLElement', () => {
     const elem = document.createTextNode('Hello');
+    container.appendChild(elem);
     expect(rule2C(elem)).toBe(null);
   });
 

--- a/src/lib/rule2C_test.ts
+++ b/src/lib/rule2C_test.ts
@@ -1,0 +1,70 @@
+import {html, render} from 'lit-html';
+import {rule2C} from './rule2C';
+import {getDefaultContext} from './context';
+
+describe('The function for rule 2C', () => {
+  let container: HTMLElement;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('returns null if node does not contain an aria-label attribute', () => {
+    render(html`<div id="foo"></div>`, container);
+    const elem = document.getElementById('foo');
+    expect(rule2C(elem!)).toBe(null);
+  });
+
+  it('returns null if node is not HTMLElement', () => {
+    const elem = document.createTextNode('Hello');
+    expect(rule2C(elem)).toBe(null);
+  });
+
+  it('returns aria-label value if node contains a non-empty aria-label attribute', () => {
+    render(html`<div id="foo" aria-label="hello"></div>`, container);
+    const elem = document.getElementById('foo');
+    expect(rule2C(elem!)).toBe('hello');
+  });
+
+  it('returns null if node contains an empty aria-label attribute, when trimmed of whitespace', () => {
+    render(html`<div id="foo" aria-label="   "></div>`, container);
+    const elem = document.getElementById('foo');
+    expect(rule2C(elem!)).toBe(null);
+  });
+
+  it('returns aria-label value for controls if they are not already part of a name', () => {
+    render(
+      html`
+        <input id="foo" aria-label="hello there" type="range" value="5" />
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2C(elem!)).toBe('hello there');
+  });
+
+  it('returns text alternative for controls if they are part of a name', () => {
+    render(
+      html`
+        <input id="foo" aria-label="hello there" type="range" value="5" />
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2C(elem!, context)).toBe('5');
+  });
+
+  it('returns aria-label value for elements that are not controls, even if they are part of a name', () => {
+    render(html` <div id="foo" aria-label="hello there" /> `, container);
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2C(elem!, context)).toBe('hello there');
+  });
+});

--- a/src/lib/rule2E.ts
+++ b/src/lib/rule2E.ts
@@ -26,10 +26,7 @@ function getValueIfTextbox(node: HTMLElement): string | null {
 
   // <input> with certain type values & no list attribute implies role='textbox'
   const nodeInputType = node.getAttribute('type')?.toLowerCase() ?? '';
-  if (
-    TEXT_INPUT_TYPES.includes(nodeInputType) &&
-    !node.hasAttribute('list')
-  ) {
+  if (TEXT_INPUT_TYPES.includes(nodeInputType) && !node.hasAttribute('list')) {
     return node.value;
   }
 
@@ -46,15 +43,15 @@ function getValueIfTextbox(node: HTMLElement): string | null {
  * combobox or listbox, null otherwise.
  * (null indicates that node is neither combobox nor listbox).
  */
-function getValueIfComboboxOrListbox(node: HTMLElement, context: Context): string | null {
+function getValueIfComboboxOrListbox(
+  node: HTMLElement,
+  context: Context
+): string | null {
   // Combobox role implied by input type and presence of list attribute,
   // chosen option is the input value.
   if (node instanceof HTMLInputElement) {
     const nodeInputType = node.getAttribute('type')?.toLowerCase() ?? '';
-    if (
-      TEXT_INPUT_TYPES.includes(nodeInputType) &&
-      node.hasAttribute('list')
-    ) {
+    if (TEXT_INPUT_TYPES.includes(nodeInputType) && node.hasAttribute('list')) {
       return node.value;
     }
   }
@@ -65,14 +62,20 @@ function getValueIfComboboxOrListbox(node: HTMLElement, context: Context): strin
   if (nodeRole.toLowerCase() === 'listbox') {
     // #SPEC_ASSUMPTION (E.2) : consider multiple selected options' text
     // alternatives, joining them with a space as in 2B.ii.c
-    const selectedOptionsTextAlternative = Array.from(node.childNodes).map(childNode => {
-      if (childNode instanceof HTMLElement &&
+    const selectedOptionsTextAlternative = Array.from(node.childNodes)
+      .map(childNode => {
+        if (
+          childNode instanceof HTMLElement &&
           childNode.getAttribute('aria-selected') === 'true'
         ) {
-          return computeTextAlternative(childNode, {inherited: context.inherited});
+          return computeTextAlternative(childNode, {
+            inherited: context.inherited,
+          });
         }
-      return '';
-    }).filter(alternativeText => alternativeText !== '').join(' ');
+        return '';
+      })
+      .filter(alternativeText => alternativeText !== '')
+      .join(' ');
     if (selectedOptionsTextAlternative) {
       return selectedOptionsTextAlternative;
     }
@@ -84,7 +87,9 @@ function getValueIfComboboxOrListbox(node: HTMLElement, context: Context): strin
     // alternatives, joining them with a space as in 2B.ii.c
     const selectedOptionsTextAlternative = Array.from(node.selectedOptions)
       .map(optionElem => {
-        return computeTextAlternative(optionElem, {inherited: context.inherited});
+        return computeTextAlternative(optionElem, {
+          inherited: context.inherited,
+        });
       })
       .filter(alternativeText => alternativeText !== '')
       .join(' ');
@@ -108,18 +113,16 @@ const RANGE_INPUT_TYPES = ['number', 'range'];
  */
 function getValueIfRange(node: HTMLElement): string | null {
   const nodeRoleAttribute = node.getAttribute('role')?.toLowerCase() ?? '';
-  const isExplicitRange = (
+  const isExplicitRange =
     nodeRoleAttribute === 'spinbutton' ||
     nodeRoleAttribute === 'slider' ||
     nodeRoleAttribute === 'progressbar' ||
-    nodeRoleAttribute === 'scrollbar'
-  );
+    nodeRoleAttribute === 'scrollbar';
 
   const nodeTypeAttribute = node.getAttribute('type')?.toLowerCase() ?? '';
-  const isImplicitRange = (
+  const isImplicitRange =
     RANGE_INPUT_TYPES.includes(nodeTypeAttribute) ||
-    node instanceof HTMLProgressElement
-  );
+    node instanceof HTMLProgressElement;
 
   if (isExplicitRange || isImplicitRange) {
     if (node.hasAttribute('aria-valuetext')) {
@@ -148,7 +151,7 @@ function getValueIfRange(node: HTMLElement): string | null {
  */
 export function rule2E(
   node: Node,
-  context: Context = getDefaultContext()
+  context = getDefaultContext()
 ): string | null {
   if (!(node instanceof HTMLElement)) {
     return null;

--- a/src/lib/rule2E.ts
+++ b/src/lib/rule2E.ts
@@ -5,12 +5,12 @@ import {computeTextAlternative} from './compute_text_alternative';
 const TEXTBOX_INPUT_TYPES = ['email', 'tel', 'text', 'url'];
 
 /**
- * Checks if input elem has role 'textbox' or has a list attribute
+ * Checks if input elem has role 'textbox' or 'combobox'
  * @param elem - input element whose role is being calculated
  * @return - true if elem has role 'textbox' or list attribute,
  * false otherwise.
  */
-function isTextboxOrListInput(elem: HTMLInputElement): boolean {
+function isTextboxOrComboboxInput(elem: HTMLInputElement): boolean {
   const inputType = elem.getAttribute('type')?.toLowerCase() ?? '';
   return TEXTBOX_INPUT_TYPES.includes(inputType) || elem.hasAttribute('list');
 }
@@ -19,7 +19,8 @@ function isTextboxOrListInput(elem: HTMLInputElement): boolean {
 const RANGE_INPUT_TYPES = ['number', 'range'];
 
 /**
- * Checks if input elem has role 'range'
+ * Checks if input elem is a 'range' input,
+ * i.e has role 'slider' or 'spinbutton'
  * @param elem - input element whose role is being calculated
  * @return - true if elem has role 'range', false otherwise
  */
@@ -43,32 +44,32 @@ export function rule2E(
     return null;
   }
 
+  // #SPEC_ASSUMPTION (E.3) : controls with explicit roles are
+  // handled by rule2F
+
   // #SPEC_ASSUMPTION (E.1) : that 'embedded within the label
   // for another widget' is equivalent to 'part of a name computation'
   if (!context.inherited.partOfName) {
     return null;
   }
 
+  // textarea nodeName implies role=textbox
   if (node instanceof HTMLTextAreaElement) {
     return node.value;
   }
 
-  if (node instanceof HTMLInputElement && isTextboxOrListInput(node)) {
+  // Handles textboxes and comboboxes that are <input> elements
+  if (node instanceof HTMLInputElement && isTextboxOrComboboxInput(node)) {
     return node.value;
   }
 
+  // Handles comboboxes and listboxes that are <select> elements
   if (node instanceof HTMLSelectElement) {
-    const textAlterantives = [];
     // #SPEC_ASSUMPTION (E.2) : consider multiple selected options' text
     // alternatives, joining them with a space as in 2B.ii.c
-    for (const optionNode of node.selectedOptions) {
-      context.inherited.partOfName = true;
-      const textAlterantive = computeTextAlternative(optionNode, {
-        inherited: context.inherited,
-      });
-      textAlterantives.push(textAlterantive);
-    }
-    return textAlterantives.filter(text => text !== '').join(' ');
+    return Array.from(node.selectedOptions).map((optionElem) => {
+      return computeTextAlternative(optionElem, {inherited: context.inherited});
+    }).filter(alternativeText => alternativeText !== '').join(' ');
   }
 
   if (node instanceof HTMLInputElement && isRangeInput(node)) {

--- a/src/lib/rule2E.ts
+++ b/src/lib/rule2E.ts
@@ -1,0 +1,85 @@
+import {Context, getDefaultContext} from './context';
+import {computeTextAlternative} from './compute_text_alternative';
+
+// Input types that imply role 'textbox'
+const TEXTBOX_INPUT_TYPES = ['email', 'tel', 'text', 'url'];
+
+/**
+ * Checks if input elem has role 'textbox' or has a list attribute
+ * @param elem - input element whose role is being calculated
+ * @return - true if elem has role 'textbox' or list attribute,
+ * false otherwise.
+ */
+function isTextboxOrListInput(elem: HTMLInputElement): boolean {
+  const inputType = elem.getAttribute('type')?.toLowerCase() ?? '';
+  return TEXTBOX_INPUT_TYPES.includes(inputType) || elem.hasAttribute('list');
+}
+
+// Input types that imply role 'range'
+const RANGE_INPUT_TYPES = ['number', 'range'];
+
+/**
+ * Checks if input elem has role 'range'
+ * @param elem - input element whose role is being calculated
+ * @return - true if elem has role 'range', false otherwise
+ */
+function isRangeInput(elem: HTMLInputElement): boolean {
+  const inputType = elem.getAttribute('type')?.toLowerCase() ?? '';
+  return RANGE_INPUT_TYPES.includes(inputType);
+}
+
+/**
+ * Implementation for rule 2E.
+ * @param node - node whose text alternative is being calculated
+ * @param context - additional information relevant to the computation of a text
+ * alternative for node.
+ * @return text alternative for 'node' if rule 2E accepts 'node', null otherwise.
+ */
+export function rule2E(
+  node: Node,
+  context: Context = getDefaultContext()
+): string | null {
+  if (!(node instanceof HTMLElement)) {
+    return null;
+  }
+
+  // #SPEC_ASSUMPTION (E.1) : that 'embedded within the label
+  // for another widget' is equivalent to 'part of a name computation'
+  if (!context.inherited.partOfName) {
+    return null;
+  }
+
+  if (node instanceof HTMLTextAreaElement) {
+    return node.value;
+  }
+
+  if (node instanceof HTMLInputElement && isTextboxOrListInput(node)) {
+    return node.value;
+  }
+
+  if (node instanceof HTMLSelectElement) {
+    const textAlterantives = [];
+    // #SPEC_ASSUMPTION (E.2) : consider multiple selected options' text
+    // alternatives, joining them with a space as in 2B.ii.c
+    for (const optionNode of node.selectedOptions) {
+      context.inherited.partOfName = true;
+      const textAlterantive = computeTextAlternative(optionNode, {
+        inherited: context.inherited,
+      });
+      textAlterantives.push(textAlterantive);
+    }
+    return textAlterantives.filter(text => text !== '').join(' ');
+  }
+
+  if (node instanceof HTMLInputElement && isRangeInput(node)) {
+    if (node.hasAttribute('aria-valuetext')) {
+      return node.getAttribute('aria-valuetext');
+    }
+    if (node.hasAttribute('aria-valuenow')) {
+      return node.getAttribute('aria-valuenow');
+    }
+    return node.value;
+  }
+
+  return null;
+}

--- a/src/lib/rule2E.ts
+++ b/src/lib/rule2E.ts
@@ -17,7 +17,7 @@ function getValueIfTextbox(node: HTMLElement): string | null {
   // [This may need to be updated -- see #SPEC_ASSUMPTION (E.4)]
 
   // Handles the case where node role is explictly overwritten
-  const nodeRole = node.getAttribute('role')?.toLowerCase();
+  const nodeRole = node.getAttribute('role');
   if (nodeRole && nodeRole !== 'textbox') {
     return null;
   }
@@ -54,17 +54,19 @@ function getValueIfComboboxOrListbox(
   context: Context
 ): string | null {
   // Handles the case where node role is explictly overwritten
-  const nodeRole = node.getAttribute('role')?.toLowerCase();
+  const nodeRole = node.getAttribute('role');
   if (nodeRole && nodeRole !== 'listbox' && nodeRole !== 'combobox') {
     return null;
   }
 
   // Combobox role implied by input type and presence of list attribute,
   // chosen option is the input value.
-  if (node instanceof HTMLInputElement) {
-    if (TEXT_INPUT_TYPES.includes(node.type) && node.hasAttribute('list')) {
-      return node.value;
-    }
+  if (
+    node instanceof HTMLInputElement &&
+    TEXT_INPUT_TYPES.includes(node.type) &&
+    node.hasAttribute('list')
+  ) {
+    return node.value;
   }
 
   // Text alternative for elems of role 'listbox' and 'combobox'
@@ -84,7 +86,7 @@ function getValueIfComboboxOrListbox(
 
   // If the current node has any selected options (either by aria-selected
   // or semantic <option selected>) they will be stored in selectedOptions.
-  if (selectedOptions) {
+  if (selectedOptions.length > 0) {
     // #SPEC_ASSUMPTION (E.2) : consider multiple selected options' text
     // alternatives, joining them with a space as in 2B.ii.c
     return selectedOptions
@@ -103,6 +105,10 @@ function getValueIfComboboxOrListbox(
 // Input types that imply role 'range'
 const RANGE_INPUT_TYPES = ['number', 'range'];
 
+// Roles for whom 'range' is a superclass.
+// Each of these roles explicitly defines the 'range' role.
+const RANGE_ROLES = ['spinbutton', 'slider', 'progressbar', 'scrollbar'];
+
 /**
  * Determines whether a given node has role 'range' and,
  * if so, gets the text alternative for that node.
@@ -111,12 +117,8 @@ const RANGE_INPUT_TYPES = ['number', 'range'];
  * null otherwise (indicating that node is not a range).
  */
 function getValueIfRange(node: HTMLElement): string | null {
-  const nodeRoleAttribute = node.getAttribute('role')?.toLowerCase();
-  const isExplicitRange =
-    nodeRoleAttribute === 'spinbutton' ||
-    nodeRoleAttribute === 'slider' ||
-    nodeRoleAttribute === 'progressbar' ||
-    nodeRoleAttribute === 'scrollbar';
+  const nodeRoleAttribute = node.getAttribute('role') ?? '';
+  const isExplicitRange = RANGE_ROLES.includes(nodeRoleAttribute);
 
   // Handles the case where node role is explictly overwritten
   if (nodeRoleAttribute && !isExplicitRange) {
@@ -176,6 +178,7 @@ export function rule2E(
   }
 
   // menu button is handled by 2F (buttons allow name from content)
+  // [See #SPEC_ASSUMPTION (E.3)]
 
   const comboboxOrListboxValue = getValueIfComboboxOrListbox(node, context);
   if (comboboxOrListboxValue) {

--- a/src/lib/rule2E.ts
+++ b/src/lib/rule2E.ts
@@ -13,8 +13,7 @@ const TEXT_INPUT_TYPES = ['email', 'tel', 'text', 'url', 'search'];
  * (null indicates that node is not a textbox).
  */
 function getValueIfTextbox(node: HTMLElement): string | null {
-  // Explicit role='textbox' are handled by rule2F.
-  // [This may need to be updated -- see #SPEC_ASSUMPTION (E.4)]
+  // #SPEC_ASSUMPTION (E.3) : Explicit role='textbox' are handled by rule2F.
 
   // Handles the case where node role is explictly overwritten
   const nodeRole = node.getAttribute('role');
@@ -163,9 +162,6 @@ export function rule2E(
     return null;
   }
 
-  // #SPEC_ASSUMPTION (E.3) : controls whose text alternative
-  // is their text content are handled by rule2F.
-
   // #SPEC_ASSUMPTION (E.1) : that 'embedded within the label
   // for another widget' is equivalent to 'part of a name computation'
   if (!context.inherited.partOfName) {
@@ -177,8 +173,7 @@ export function rule2E(
     return textboxValue;
   }
 
-  // menu button is handled by 2F (buttons allow name from content)
-  // [See #SPEC_ASSUMPTION (E.3)]
+  // #SPEC_ASSUMPTION (E.4) : menu button is handled by 2F
 
   const comboboxOrListboxValue = getValueIfComboboxOrListbox(node, context);
   if (comboboxOrListboxValue) {

--- a/src/lib/rule2E.ts
+++ b/src/lib/rule2E.ts
@@ -1,32 +1,142 @@
 import {Context, getDefaultContext} from './context';
 import {computeTextAlternative} from './compute_text_alternative';
 
-// Input types that imply role 'textbox'
-const TEXTBOX_INPUT_TYPES = ['email', 'tel', 'text', 'url'];
+// Input types that imply role 'textbox' if list attribute is not present,
+// and imply role 'combobox' if list attribute is present.
+const TEXT_INPUT_TYPES = ['email', 'tel', 'text', 'url', 'search'];
 
 /**
- * Checks if input elem has role 'textbox' or 'combobox'
- * @param elem - input element whose role is being calculated
- * @return - true if elem has role 'textbox' or list attribute,
- * false otherwise.
+ * Determines whether a given node has role 'textbox' and,
+ * if so, gets the value of that textbox.
+ * @param node - element whose role is being calculated
+ * @return - textbox value if node is a textbox, null otherwise
+ * (null indicates that node is not a textbox).
  */
-function isTextboxOrComboboxInput(elem: HTMLInputElement): boolean {
-  const inputType = elem.getAttribute('type')?.toLowerCase() ?? '';
-  return TEXTBOX_INPUT_TYPES.includes(inputType) || elem.hasAttribute('list');
+function getValueIfTextbox(node: HTMLElement): string | null {
+  // Explicit role='textbox' (elements not of type <input>) handled by rule2F
+
+  // type <textarea> implies role='textbox'
+  if (node instanceof HTMLTextAreaElement) {
+    return node.value;
+  }
+
+  if (!(node instanceof HTMLInputElement)) {
+    return null;
+  }
+
+  // <input> with certain type values & no list attribute implies role='textbox'
+  const nodeInputType = node.getAttribute('type')?.toLowerCase() ?? '';
+  if (
+    TEXT_INPUT_TYPES.includes(nodeInputType) &&
+    !node.hasAttribute('list')
+  ) {
+    return node.value;
+  }
+
+  return null;
+}
+
+/**
+ * Determines whether a given node has role 'combobox'
+ * or 'listbox' and, if so, gets the text alternative for the
+ * option(s) selected by that combobox / listbox.
+ * @param node - node whose role is being calculated
+ * @param context - information relevant to the calculation of that role
+ * @return - text alternative for selected option(s) if node is a
+ * combobox or listbox, null otherwise.
+ * (null indicates that node is neither combobox nor listbox).
+ */
+function getValueIfComboboxOrListbox(node: HTMLElement, context: Context): string | null {
+  // Combobox role implied by input type and presence of list attribute,
+  // chosen option is the input value.
+  if (node instanceof HTMLInputElement) {
+    const nodeInputType = node.getAttribute('type')?.toLowerCase() ?? '';
+    if (
+      TEXT_INPUT_TYPES.includes(nodeInputType) &&
+      node.hasAttribute('list')
+    ) {
+      return node.value;
+    }
+  }
+
+  // Listbox may be defined explicitly using 'role',
+  // and using 'aria-selected' attribute to mark selected options.
+  const nodeRole = node.getAttribute('role') ?? '';
+  if (nodeRole.toLowerCase() === 'listbox') {
+    // #SPEC_ASSUMPTION (E.2) : consider multiple selected options' text
+    // alternatives, joining them with a space as in 2B.ii.c
+    const selectedOptionsTextAlternative = Array.from(node.childNodes).map(childNode => {
+      if (childNode instanceof HTMLElement &&
+          childNode.getAttribute('aria-selected') === 'true'
+        ) {
+          return computeTextAlternative(childNode, {inherited: context.inherited});
+        }
+      return '';
+    }).filter(alternativeText => alternativeText !== '').join(' ');
+    if (selectedOptionsTextAlternative) {
+      return selectedOptionsTextAlternative;
+    }
+  }
+
+  // A <select> element is always implicitly either a listbox or a combobox
+  if (node instanceof HTMLSelectElement) {
+    // #SPEC_ASSUMPTION (E.2) : consider multiple selected options' text
+    // alternatives, joining them with a space as in 2B.ii.c
+    const selectedOptionsTextAlternative = Array.from(node.selectedOptions)
+      .map(optionElem => {
+        return computeTextAlternative(optionElem, {inherited: context.inherited});
+      })
+      .filter(alternativeText => alternativeText !== '')
+      .join(' ');
+    if (selectedOptionsTextAlternative) {
+      return selectedOptionsTextAlternative;
+    }
+  }
+
+  return null;
 }
 
 // Input types that imply role 'range'
 const RANGE_INPUT_TYPES = ['number', 'range'];
 
 /**
- * Checks if input elem is a 'range' input,
- * i.e has role 'slider' or 'spinbutton'
- * @param elem - input element whose role is being calculated
- * @return - true if elem has role 'range', false otherwise
+ * Determines whether a given node has role 'range' and,
+ * if so, gets the text alternative for that node.
+ * @param node - node whose role is being calculated
+ * @return - text alternative for node if node is a 'range',
+ * null otherwise (indicating that node is not a range).
  */
-function isRangeInput(elem: HTMLInputElement): boolean {
-  const inputType = elem.getAttribute('type')?.toLowerCase() ?? '';
-  return RANGE_INPUT_TYPES.includes(inputType);
+function getValueIfRange(node: HTMLElement): string | null {
+  const nodeRoleAttribute = node.getAttribute('role')?.toLowerCase() ?? '';
+  const isExplicitRange = (
+    nodeRoleAttribute === 'spinbutton' ||
+    nodeRoleAttribute === 'slider' ||
+    nodeRoleAttribute === 'progressbar' ||
+    nodeRoleAttribute === 'scrollbar'
+  );
+
+  const nodeTypeAttribute = node.getAttribute('type')?.toLowerCase() ?? '';
+  const isImplicitRange = (
+    RANGE_INPUT_TYPES.includes(nodeTypeAttribute) ||
+    node instanceof HTMLProgressElement
+  );
+
+  if (isExplicitRange || isImplicitRange) {
+    if (node.hasAttribute('aria-valuetext')) {
+      return node.getAttribute('aria-valuetext');
+    }
+    if (node.hasAttribute('aria-valuenow')) {
+      return node.getAttribute('aria-valuenow');
+    }
+    if (node instanceof HTMLInputElement) {
+      return node.value;
+    }
+    if (node instanceof HTMLProgressElement) {
+      return node.value.toString();
+    }
+  }
+
+  return null;
 }
 
 /**
@@ -44,8 +154,8 @@ export function rule2E(
     return null;
   }
 
-  // #SPEC_ASSUMPTION (E.3) : controls with explicit roles are
-  // handled by rule2F
+  // #SPEC_ASSUMPTION (E.3) : controls whose text alternative
+  // is their text content are handled by rule2F.
 
   // #SPEC_ASSUMPTION (E.1) : that 'embedded within the label
   // for another widget' is equivalent to 'part of a name computation'
@@ -53,38 +163,21 @@ export function rule2E(
     return null;
   }
 
-  // textarea nodeName implies role=textbox
-  if (node instanceof HTMLTextAreaElement) {
-    return node.value;
+  const textboxValue = getValueIfTextbox(node);
+  if (textboxValue) {
+    return textboxValue;
   }
 
-  // Handles textboxes and comboboxes that are <input> elements
-  if (node instanceof HTMLInputElement && isTextboxOrComboboxInput(node)) {
-    return node.value;
+  // menu button is handled by 2F (buttons allow name from content)
+
+  const comboboxOrListboxValue = getValueIfComboboxOrListbox(node, context);
+  if (comboboxOrListboxValue) {
+    return comboboxOrListboxValue;
   }
 
-  // Handles comboboxes and listboxes that are <select> elements
-  if (node instanceof HTMLSelectElement) {
-    // #SPEC_ASSUMPTION (E.2) : consider multiple selected options' text
-    // alternatives, joining them with a space as in 2B.ii.c
-    return Array.from(node.selectedOptions)
-      .map(optionElem => {
-        return computeTextAlternative(optionElem, {
-          inherited: context.inherited,
-        });
-      })
-      .filter(alternativeText => alternativeText !== '')
-      .join(' ');
-  }
-
-  if (node instanceof HTMLInputElement && isRangeInput(node)) {
-    if (node.hasAttribute('aria-valuetext')) {
-      return node.getAttribute('aria-valuetext');
-    }
-    if (node.hasAttribute('aria-valuenow')) {
-      return node.getAttribute('aria-valuenow');
-    }
-    return node.value;
+  const rangeValue = getValueIfRange(node);
+  if (rangeValue) {
+    return rangeValue;
   }
 
   return null;

--- a/src/lib/rule2E.ts
+++ b/src/lib/rule2E.ts
@@ -67,9 +67,14 @@ export function rule2E(
   if (node instanceof HTMLSelectElement) {
     // #SPEC_ASSUMPTION (E.2) : consider multiple selected options' text
     // alternatives, joining them with a space as in 2B.ii.c
-    return Array.from(node.selectedOptions).map((optionElem) => {
-      return computeTextAlternative(optionElem, {inherited: context.inherited});
-    }).filter(alternativeText => alternativeText !== '').join(' ');
+    return Array.from(node.selectedOptions)
+      .map(optionElem => {
+        return computeTextAlternative(optionElem, {
+          inherited: context.inherited,
+        });
+      })
+      .filter(alternativeText => alternativeText !== '')
+      .join(' ');
   }
 
   if (node instanceof HTMLInputElement && isRangeInput(node)) {

--- a/src/lib/rule2E.ts
+++ b/src/lib/rule2E.ts
@@ -17,7 +17,7 @@ function getValueIfTextbox(node: HTMLElement): string | null {
   // [This may need to be updated -- see #SPEC_ASSUMPTION (E.4)]
 
   // Handles the case where node role is explictly overwritten
-  const nodeRole = node.getAttribute('role');
+  const nodeRole = node.getAttribute('role')?.toLowerCase();
   if (nodeRole && nodeRole !== 'textbox') {
     return null;
   }
@@ -54,12 +54,8 @@ function getValueIfComboboxOrListbox(
   context: Context
 ): string | null {
   // Handles the case where node role is explictly overwritten
-  const nodeRole = node.getAttribute('role');
-  if (
-    nodeRole &&
-    nodeRole.toLowerCase() !== 'listbox' &&
-    nodeRole.toLowerCase() !== 'combobox'
-  ) {
+  const nodeRole = node.getAttribute('role')?.toLowerCase();
+  if (nodeRole && nodeRole !== 'listbox' && nodeRole !== 'combobox') {
     return null;
   }
 
@@ -76,7 +72,7 @@ function getValueIfComboboxOrListbox(
   let selectedOptions: HTMLElement[] = [];
   // Listbox may be defined explicitly using 'role',
   // and using 'aria-selected' attribute to mark selected options.
-  if (nodeRole && nodeRole.toLowerCase() === 'listbox') {
+  if (nodeRole && nodeRole === 'listbox') {
     selectedOptions = Array.from(
       node.querySelectorAll('[role="option"][aria-selected="true"]')
     );

--- a/src/lib/rule2E_test.ts
+++ b/src/lib/rule2E_test.ts
@@ -127,9 +127,7 @@ describe('The function for rule 2E', () => {
 
   it('gives aria-valuetext priority over native value for range input', () => {
     render(
-      html`
-        <input id="foo" type="range" value="6" aria-valuetext="5" />
-      `,
+      html` <input id="foo" type="range" value="6" aria-valuetext="5" /> `,
       container
     );
     const elem = document.getElementById('foo');
@@ -140,9 +138,7 @@ describe('The function for rule 2E', () => {
 
   it('gives aria-valuenow priority over native value for range input', () => {
     render(
-      html`
-        <input id="foo" type="range" value="6" aria-valuenow="5" />
-      `,
+      html` <input id="foo" type="range" value="6" aria-valuenow="5" /> `,
       container
     );
     const elem = document.getElementById('foo');

--- a/src/lib/rule2E_test.ts
+++ b/src/lib/rule2E_test.ts
@@ -1,0 +1,127 @@
+import {html, render} from 'lit-html';
+import {getDefaultContext} from './context';
+import {rule2E} from './rule2E';
+
+describe('The function for rule 2E', () => {
+  let container: HTMLElement;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('returns null if the node is not part of a name', () => {
+    render(html`<div id="foo">Hello</div>`, container);
+    const elem = document.getElementById('foo');
+    expect(rule2E(elem!)).toBe(null);
+  });
+
+  it('returns null if the node is not a HTMLElement', () => {
+    const node = document.createTextNode('Hello');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(node, context)).toBe(null);
+  });
+
+  it('returns text content of textArea', () => {
+    render(html`<textarea id="foo">Hello world</textarea>`, container);
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('Hello world');
+  });
+
+  it('returns text content for inputs whose types imply textbox role', () => {
+    render(html`<input id="foo" type="email" value="hello" />`, container);
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('hello');
+  });
+
+  it('returns text content for inputs with list attributes', () => {
+    render(html`<input id="foo" list value="hello" />`, container);
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('hello');
+  });
+
+  it('returns text alternative of selected option in select element', () => {
+    render(
+      html`
+        <select id="foo">
+          <option>Hello</option>
+          <option selected>world</option>
+        </select>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('world');
+  });
+
+  it('returns text alternative for multiple selected options in select element', () => {
+    render(
+      html`
+        <select id="foo" multiple>
+          <option selected>Hello</option>
+          <option selected>world</option>
+        </select>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('Hello world');
+  });
+
+  it('returns aria-valuetext value if present in range input', () => {
+    render(
+      html` <input id="foo" type="range" aria-valuetext="5" /> `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('5');
+  });
+
+  it('returns aria-valuenow value if present in range input', () => {
+    render(
+      html` <input id="foo" type="range" aria-valuenow="5" /> `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('5');
+  });
+
+  it('gives aria-valuetext priority over aria-valuenow for range input', () => {
+    render(
+      html`
+        <input id="foo" type="range" aria-valuenow="6" aria-valuetext="5" />
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('5');
+  });
+
+  it('returns range input value if neither aria-valuetext nor aria-valuenow are present', () => {
+    render(html` <input id="foo" type="range" value="5" /> `, container);
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('5');
+  });
+});

--- a/src/lib/rule2E_test.ts
+++ b/src/lib/rule2E_test.ts
@@ -43,7 +43,10 @@ describe('The function for rule 2E', () => {
   });
 
   it('returns text content for type=email inputs with list attributes (combobox role)', () => {
-    render(html`<input id="foo" type="email" list="emails" value="hello" />`, container);
+    render(
+      html`<input id="foo" type="email" list="emails" value="hello" />`,
+      container
+    );
     const elem = document.getElementById('foo');
     const context = getDefaultContext();
     context.inherited.partOfName = true;
@@ -85,12 +88,12 @@ describe('The function for rule 2E', () => {
   it('returns text alternative for selected options in explicitly defined listbox', () => {
     render(
       html`
-      <div id="foo" role="listbox">
-        <div aria-selected="true">Green</div>
-        <div>Orange</div>
-        <div>Red</div>
-        <div>Blue</div>
-      </div>
+        <div id="foo" role="listbox">
+          <div aria-selected="true">Green</div>
+          <div>Orange</div>
+          <div>Red</div>
+          <div>Blue</div>
+        </div>
       `,
       container
     );
@@ -103,12 +106,12 @@ describe('The function for rule 2E', () => {
   it('returns text alternative for multiple selected options in explicitly defined listbox', () => {
     render(
       html`
-      <div id="foo" role="listbox">
-        <div aria-selected="true">Green</div>
-        <div aria-selected="true">Orange</div>
-        <div>Red</div>
-        <div>Blue</div>
-      </div>
+        <div id="foo" role="listbox">
+          <div aria-selected="true">Green</div>
+          <div aria-selected="true">Orange</div>
+          <div>Red</div>
+          <div>Blue</div>
+        </div>
       `,
       container
     );
@@ -122,12 +125,12 @@ describe('The function for rule 2E', () => {
   it('returns null if no options are selected in explicitly defined listbox', () => {
     render(
       html`
-      <div id="foo" role="listbox">
-        <div>Green</div>
-        <div>Orange</div>
-        <div>Red</div>
-        <div>Blue</div>
-      </div>
+        <div id="foo" role="listbox">
+          <div>Green</div>
+          <div>Orange</div>
+          <div>Red</div>
+          <div>Blue</div>
+        </div>
       `,
       container
     );
@@ -203,10 +206,7 @@ describe('The function for rule 2E', () => {
   });
 
   it('returns value attribute if input is explicitly defined as range and neither aria-valuenow nor aria-valuetext are present', () => {
-    render(
-      html` <input id="foo" role="spinbutton" value="5" /> `,
-      container
-    );
+    render(html` <input id="foo" role="spinbutton" value="5" /> `, container);
     const elem = document.getElementById('foo');
     const context = getDefaultContext();
     context.inherited.partOfName = true;

--- a/src/lib/rule2E_test.ts
+++ b/src/lib/rule2E_test.ts
@@ -89,10 +89,10 @@ describe('The function for rule 2E', () => {
     render(
       html`
         <div id="foo" role="listbox">
-          <div aria-selected="true">Green</div>
-          <div>Orange</div>
-          <div>Red</div>
-          <div>Blue</div>
+          <div role="option" aria-selected="true">Green</div>
+          <div role="option">Orange</div>
+          <div role="option">Red</div>
+          <div role="option">Blue</div>
         </div>
       `,
       container
@@ -107,10 +107,10 @@ describe('The function for rule 2E', () => {
     render(
       html`
         <div id="foo" role="listbox">
-          <div aria-selected="true">Green</div>
-          <div aria-selected="true">Orange</div>
-          <div>Red</div>
-          <div>Blue</div>
+          <div role="option" aria-selected="true">Green</div>
+          <div role="option" aria-selected="true">Orange</div>
+          <div role="option">Red</div>
+          <div role="option">Blue</div>
         </div>
       `,
       container
@@ -126,10 +126,10 @@ describe('The function for rule 2E', () => {
     render(
       html`
         <div id="foo" role="listbox">
-          <div>Green</div>
-          <div>Orange</div>
-          <div>Red</div>
-          <div>Blue</div>
+          <div role="option">Green</div>
+          <div role="option">Orange</div>
+          <div role="option">Red</div>
+          <div role="option">Blue</div>
         </div>
       `,
       container
@@ -222,5 +222,42 @@ describe('The function for rule 2E', () => {
     const context = getDefaultContext();
     context.inherited.partOfName = true;
     expect(rule2E(elem!, context)).toBe('5');
+  });
+
+  it('considers implicit textbox role being explicitly overwritten', () => {
+    render(
+      html` <textarea id="foo" role="spinbutton">Hello world</textarea> `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe(null);
+  });
+
+  it('considers implicit listbox / combobox role being explicitly overwritten', () => {
+    render(
+      html`
+        <select id="foo" role="spinbutton">
+          <option selected>Hello world</option>
+        </select>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe(null);
+  });
+
+  it('considers implicit range role being explicitly overwritten', () => {
+    render(
+      html` <input id="foo" type="number" role="textbox" value="5" /> `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe(null);
   });
 });

--- a/src/lib/rule2E_test.ts
+++ b/src/lib/rule2E_test.ts
@@ -124,4 +124,30 @@ describe('The function for rule 2E', () => {
     context.inherited.partOfName = true;
     expect(rule2E(elem!, context)).toBe('5');
   });
+
+  it('gives aria-valuetext priority over native value for range input', () => {
+    render(
+      html`
+        <input id="foo" type="range" value="6" aria-valuetext="5" />
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('5');
+  });
+
+  it('gives aria-valuenow priority over native value for range input', () => {
+    render(
+      html`
+        <input id="foo" type="range" value="6" aria-valuenow="5" />
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('5');
+  });
 });

--- a/src/lib/rule2E_test.ts
+++ b/src/lib/rule2E_test.ts
@@ -42,8 +42,8 @@ describe('The function for rule 2E', () => {
     expect(rule2E(elem!, context)).toBe('hello');
   });
 
-  it('returns text content for inputs with list attributes', () => {
-    render(html`<input id="foo" list value="hello" />`, container);
+  it('returns text content for type=email inputs with list attributes (combobox role)', () => {
+    render(html`<input id="foo" type="email" list="emails" value="hello" />`, container);
     const elem = document.getElementById('foo');
     const context = getDefaultContext();
     context.inherited.partOfName = true;
@@ -80,6 +80,61 @@ describe('The function for rule 2E', () => {
     const context = getDefaultContext();
     context.inherited.partOfName = true;
     expect(rule2E(elem!, context)).toBe('Hello world');
+  });
+
+  it('returns text alternative for selected options in explicitly defined listbox', () => {
+    render(
+      html`
+      <div id="foo" role="listbox">
+        <div aria-selected="true">Green</div>
+        <div>Orange</div>
+        <div>Red</div>
+        <div>Blue</div>
+      </div>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('Green');
+  });
+
+  it('returns text alternative for multiple selected options in explicitly defined listbox', () => {
+    render(
+      html`
+      <div id="foo" role="listbox">
+        <div aria-selected="true">Green</div>
+        <div aria-selected="true">Orange</div>
+        <div>Red</div>
+        <div>Blue</div>
+      </div>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('Green Orange');
+  });
+
+  // Should empty string be returned in this case?
+  it('returns null if no options are selected in explicitly defined listbox', () => {
+    render(
+      html`
+      <div id="foo" role="listbox">
+        <div>Green</div>
+        <div>Orange</div>
+        <div>Red</div>
+        <div>Blue</div>
+      </div>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe(null);
   });
 
   it('returns aria-valuetext value if present in range input', () => {
@@ -139,6 +194,28 @@ describe('The function for rule 2E', () => {
   it('gives aria-valuenow priority over native value for range input', () => {
     render(
       html` <input id="foo" type="range" value="6" aria-valuenow="5" /> `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('5');
+  });
+
+  it('returns value attribute if input is explicitly defined as range and neither aria-valuenow nor aria-valuetext are present', () => {
+    render(
+      html` <input id="foo" role="spinbutton" value="5" /> `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('5');
+  });
+
+  it('returns value attribute of progress element if neither aria-valuenow nor aria-valuetext are present', () => {
+    render(
+      html` <progress id="foo" max="10" value="5"></progress> `,
       container
     );
     const elem = document.getElementById('foo');

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -190,7 +190,7 @@ function getCssContent(elem: HTMLElement, pseudoElementName: string): string {
  */
 export function rule2F(
   node: Node,
-  context: Context = getDefaultContext()
+  context = getDefaultContext()
 ): string | null {
   if (!(node instanceof HTMLElement)) {
     return null;


### PR DESCRIPTION
- Added implementations and tests for 2C, 2E
- Added a test for `computeTextAlternative()` that tests 2C and 2E together.
- I've labelled and [described](https://docs.google.com/document/d/1bZDsS6yT3b_kpAIiltdZTYxAfdWFtFrWTTN-soKp1Bs/edit?usp=sharing) any spec assumptions that I could identify.
- Added a check in the condition for rule 2A that handles hidden `<option>`s in Chrome.