### PR TITLE
Implementation for rule 2D

### DIFF
--- a/src/lib/compute_text_alternative.ts
+++ b/src/lib/compute_text_alternative.ts
@@ -2,6 +2,7 @@ import {Context, getDefaultContext} from './context';
 import {rule2A} from './rule2A';
 import {rule2B} from './rule2B';
 import {rule2C} from './rule2C';
+import {rule2D} from './rule2D';
 import {rule2E} from './rule2E';
 import {rule2F} from './rule2F';
 import {rule2G} from './rule2G';
@@ -29,6 +30,11 @@ export function computeTextAlternative(
   }
 
   result = rule2C(node, context);
+  if (result !== null) {
+    return result;
+  }
+
+  result = rule2D(node, context);
   if (result !== null) {
     return result;
   }

--- a/src/lib/rule2D.ts
+++ b/src/lib/rule2D.ts
@@ -1,0 +1,176 @@
+import {Context, getDefaultContext} from './context';
+import {computeTextAlternative} from './compute_text_alternative';
+
+const INPUT_TYPES_WITH_VALUE_AS_ALT_TEXT = ['button', 'submit', 'reset'];
+
+/**
+ * Process elem's text alternative if elem is an <input>, assuming
+ * that no <label> element references elem.
+ * @param elem - element whose text alternative is being processed
+ * @return - text alternative of elem if elem is an <input>
+ */
+function getUnlabelledInputText(elem: HTMLElement): string | null {
+  if (!(elem instanceof HTMLInputElement)) {
+    return null;
+  }
+
+  // Implementation reflects rules defined in sections 5.1 - 5.3 of html-aam spec:
+  // https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation
+
+  const inputType = elem.getAttribute('type') ?? '';
+  if (
+    INPUT_TYPES_WITH_VALUE_AS_ALT_TEXT.includes(inputType) &&
+    elem.hasAttribute('value')
+  ) {
+    return elem.value;
+  }
+
+  if (inputType === 'submit' || inputType === 'reset') {
+    return inputType;
+  }
+
+  if (inputType === 'image' && elem.hasAttribute('alt')) {
+    return elem.getAttribute('alt');
+  }
+
+  if (inputType === 'image' && !elem.hasAttribute('title')) {
+    return 'Submit Query';
+  }
+
+  return null;
+}
+
+// Only certain element types are labellable
+// See: https://html.spec.whatwg.org/multipage/forms.html#category-label
+const LABELLABLE_ELEMENT_TYPES = [
+  'BUTTON',
+  'INPUT',
+  'METER',
+  'OUTPUT',
+  'PROGRESS',
+  'SELECT',
+  'TEXTAREA',
+];
+
+/**
+ * Gets the text alternative as defined by one or more native <label>s.
+ * @param elem - element whose text alternative is being calculated
+ * @param context - information relevant to the computation of elem's text alternative
+ * @return - the text alternative for elem if elem is legally labelled by a native
+ * <label>, null otherwise.
+ */
+function getTextIfLabelled(elem: HTMLElement, context: Context): string | null {
+  if (!LABELLABLE_ELEMENT_TYPES.includes(elem.nodeName)) {
+    return null;
+  }
+
+  // Using querySelectorAll to get <label>s in DOM order.
+  const allLabelElems = document.querySelectorAll('label');
+  const labelElems = Array.from(allLabelElems).filter(label => {
+    return (
+      label.htmlFor === elem.id ||
+      // #SPEC_ASSUMPTION (D.2) : Consider the outermost ancestor <label> to
+      // to define the text alternative for elem.
+      (label.contains(elem) && !(label.parentElement?.closest('label') ?? null))
+    );
+  });
+
+  const textAlternative = labelElems
+    .map(labelElem => {
+      return computeTextAlternative(labelElem, {
+        directLabelReference: true,
+        inherited: context.inherited,
+      });
+    })
+    .filter(text => text !== '')
+    .join(' ');
+
+  if (textAlternative !== '') {
+    return textAlternative;
+  }
+
+  return null;
+}
+
+/**
+ * Implementation for rule 2D
+ * @param node - the node whose text alternative is being computed
+ * @param context - information relevant to the text alternative computation
+ * for node
+ * @return - text alternative for node if the conditions for applying
+ * rule 2D are satisfied, null otherwise.
+ */
+export function rule2D(
+  node: Node,
+  context: Context = getDefaultContext()
+): string | null {
+  if (!(node instanceof HTMLElement)) {
+    return null;
+  }
+
+  const roleAttribute = node.getAttribute('role') ?? '';
+  if (roleAttribute === 'presentation' || roleAttribute === 'none') {
+    return null;
+  }
+
+  // #SPEC_ASSUMPTION (D.1) : html-aam (https://www.w3.org/TR/html-aam-1.0/)
+  // specifies all native attributes and elements that define a text alternative.
+
+  const labelText = getTextIfLabelled(node, context);
+  if (labelText) {
+    return labelText;
+  }
+
+  // If input is not <label>led, use native attribute /
+  // element information to compute a text alternative
+  const inputTextAlternative = getUnlabelledInputText(node);
+  if (inputTextAlternative) {
+    return inputTextAlternative;
+  }
+
+  // <caption>s define text alternatives for <table>s
+  if (node instanceof HTMLTableElement) {
+    const captionElem = node.querySelector('caption');
+    if (captionElem) {
+      context.inherited.partOfName = true;
+      return computeTextAlternative(captionElem, {
+        inherited: context.inherited,
+      });
+    }
+  }
+
+  // <figcaption>s define text alternatives for <figure>s
+  // Checking nodeName due to lack of HTMLFigureElement
+  if (node.nodeName.toLowerCase() === 'figure') {
+    const figcaptionElem = node.querySelector('figcaption');
+    if (figcaptionElem) {
+      context.inherited.partOfName = true;
+      return computeTextAlternative(figcaptionElem, {
+        inherited: context.inherited,
+      });
+    }
+  }
+
+  // <legend>s define text alternatives for <fieldset>s
+  if (node instanceof HTMLFieldSetElement) {
+    const legendElem = node.querySelector('legend');
+    if (legendElem) {
+      context.inherited.partOfName = true;
+      return computeTextAlternative(legendElem, {
+        inherited: context.inherited,
+      });
+    }
+  }
+
+  // alt attributes define text alternatives for
+  // <img>s and <area>s
+  const altAttribute = node.getAttribute('alt');
+  if (
+    altAttribute &&
+    (node instanceof HTMLImageElement || node instanceof HTMLAreaElement)
+  ) {
+    return altAttribute;
+  }
+
+  return null;
+}

--- a/src/lib/rule2D_test.ts
+++ b/src/lib/rule2D_test.ts
@@ -72,46 +72,6 @@ describe('The function for rule 2D', () => {
     expect(rule2D(elem!)).toBe('Hello world');
   });
 
-  it('returns the text alternative of the outermost label ancestor', () => {
-    render(
-      html`
-        <label>
-          Hello
-          <label>
-            world
-            <input id="foo" />
-          </label>
-        </label>
-      `,
-      container
-    );
-    const elem = document.getElementById('foo');
-    expect(rule2D(elem!)).toBe('Hello world');
-  });
-
-  it('considers idref labels before nested labels [absurd example]', () => {
-    render(
-      html`
-        <label for="foo">Hello</label>
-        <label for="foo">world!</label>
-
-        <label>
-          Hi
-          <label>
-            there
-            <div>
-              friend
-              <input id="foo" />
-            </div>
-          </label>
-        </label>
-      `,
-      container
-    );
-    const elem = document.getElementById('foo');
-    expect(rule2D(elem!)).toBe('Hello world! Hi there friend');
-  });
-
   it('processes multiple <label>s in DOM order.', () => {
     render(
       html`

--- a/src/lib/rule2D_test.ts
+++ b/src/lib/rule2D_test.ts
@@ -1,0 +1,264 @@
+import {html, render} from 'lit-html';
+import {rule2D} from './rule2D';
+
+describe('The function for rule 2D', () => {
+  let container: HTMLElement;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('returns text alternative for native label if present', () => {
+    render(
+      html`
+        <input id="foo" type="text" />
+        <label for="foo">
+          Hello world
+        </label>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('does not allow double label traversal', () => {
+    render(
+      html`
+        <input id="foo" type="text" />
+        <label for="foo" aria-labelledby="bar">
+          Hello world
+        </label>
+        <div id="bar">Hello there</div>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('concatenates label text alternatives for multiple labels', () => {
+    render(
+      html`
+        <input id="foo" type="text" />
+        <label for="foo">
+          Hello
+        </label>
+        <label for="foo">
+          world
+        </label>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('recognises label elements that label nested inputs', () => {
+    render(
+      html`
+        <label>
+          Hello world
+          <input id="foo" />
+        </label>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('returns the text alternative of the outermost label ancestor', () => {
+    render(
+      html`
+        <label>
+          Hello
+          <label>
+            world
+            <input id="foo" />
+          </label>
+        </label>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('considers idref labels before nested labels [absurd example]', () => {
+    render(
+      html`
+        <label for="foo">Hello</label>
+        <label for="foo">world!</label>
+
+        <label>
+          Hi
+          <label>
+            there
+            <div>
+              friend
+              <input id="foo" />
+            </div>
+          </label>
+        </label>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world! Hi there friend');
+  });
+
+  it('processes multiple <label>s in DOM order.', () => {
+    render(
+      html`
+        <label for="foo">Hello</label>
+        <label>
+          there
+          <input id="foo" />
+        </label>
+        <label for="foo">world!</label>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello there world!');
+  });
+
+  it('returns null for elements with role presentation', () => {
+    render(
+      html`
+        <input id="foo" type="text" role="presentation" />
+        <label for="foo">
+          Hello world
+        </label>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe(null);
+  });
+
+  it('returns null for elements with role none', () => {
+    render(
+      html`
+        <input id="foo" type="text" role="none" />
+        <label for="foo">
+          Hello world
+        </label>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe(null);
+  });
+
+  it('returns null if node is not a HTMLElement', () => {
+    const node = document.createTextNode('Hello');
+    expect(rule2D(node)).toBe(null);
+  });
+
+  it('returns text alternative of caption element for table, if present', () => {
+    render(
+      html`
+        <table id="foo">
+          <caption>
+            Hello world
+          </caption>
+        </table>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('returns text alternative of figcaption element for figure, if present', () => {
+    render(
+      html`
+        <figure id="foo">
+          <figcaption>Hello world</figcaption>
+        </figure>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('returns text alternative of legend element for fieldset, if present', () => {
+    render(
+      html`
+        <fieldset id="foo">
+          <legend>Hello world</legend>
+        </fieldset>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('returns alt attribute value for image, if present', () => {
+    render(html` <img id="foo" alt="Hello world" /> `, container);
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('returns alt attribute value for area, if present', () => {
+    render(html` <area id="foo" alt="Hello world" /> `, container);
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('returns null if rule 2D cannot be applied to the given node', () => {
+    render(html` <div id="foo"></div> `, container);
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe(null);
+  });
+
+  it('returns input.value for inputs whose value defines alt text', () => {
+    render(
+      html` <input id="foo" type="button" value="Hello world" /> `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('returns input.type for submit inputs with no value ', () => {
+    render(html` <input id="foo" type="submit" /> `, container);
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('submit');
+  });
+
+  it('returns input.type for reset inputs with no value ', () => {
+    render(html` <input id="foo" type="reset" /> `, container);
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('reset');
+  });
+
+  it('returns input.alt for image inputs', () => {
+    render(
+      html` <input id="foo" type="image" alt="Hello world" /> `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
+
+  it('returns Submit Query for image inputs that have no alt nor title attributes', () => {
+    render(html` <input id="foo" type="image" /> `, container);
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Submit Query');
+  });
+
+  it('returns null for inputs whose type isnt specified', () => {
+    render(html` <input id="foo" /> `, container);
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe(null);
+  });
+});


### PR DESCRIPTION
This rule looks at the native elements and attributes that could define a text alternative for the current node. The [HTML-AAM spec](https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation) provides a guide to text alternative computation for such elements / attributes. This guide was very useful in implementing rule 2D and is heavily reflected in the code.