### PR TITLE
Implementation for rule 2I

### DIFF
--- a/src/lib/compute_text_alternative.ts
+++ b/src/lib/compute_text_alternative.ts
@@ -6,6 +6,7 @@ import {rule2D} from './rule2D';
 import {rule2E} from './rule2E';
 import {rule2F} from './rule2F';
 import {rule2G} from './rule2G';
+import {rule2I} from './rule2I';
 
 /**
  * @param node - The node whose text alternative will be calculated
@@ -50,6 +51,11 @@ export function computeTextAlternative(
   }
 
   result = rule2G(node);
+  if (result !== null) {
+    return result;
+  }
+
+  result = rule2I(node);
   if (result !== null) {
     return result;
   }

--- a/src/lib/rule2I.ts
+++ b/src/lib/rule2I.ts
@@ -1,0 +1,44 @@
+// Input types for whom placeholders should be considered when computing
+// a text alternative. See https://www.w3.org/TR/html-aam-1.0/#input-type-text-input-type-password-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-name-computation
+const TEXTUAL_INPUT_TYPES = [
+  'text',
+  'password',
+  'search',
+  'tel',
+  'email',
+  'url',
+];
+
+/**
+ * Implementation for rule 2I
+ * @param node - node whose text alternative is being computed
+ * @return - text alternative if rule 2I applies to node, null otherwise.
+ */
+export function rule2I(node: Node): string | null {
+  if (!(node instanceof HTMLElement)) {
+    return null;
+  }
+
+  // Title value inherited from closest ancestor (or node itself, if title is present).
+  // See https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute
+  const titleElem = node.closest('[title]') as HTMLElement;
+  if (titleElem) {
+    return titleElem.title;
+  }
+
+  // Placeholder considered if no title is present.
+  // See https://www.w3.org/TR/html-aam-1.0/#input-type-text-input-type-password-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-name-computation
+
+  if (
+    node instanceof HTMLInputElement &&
+    TEXTUAL_INPUT_TYPES.includes(node.type)
+  ) {
+    return node.placeholder;
+  }
+
+  if (node instanceof HTMLTextAreaElement && node.hasAttribute('placeholder')) {
+    return node.getAttribute('placeholder');
+  }
+
+  return null;
+}

--- a/src/lib/rule2I_test.ts
+++ b/src/lib/rule2I_test.ts
@@ -1,0 +1,66 @@
+import {html, render} from 'lit-html';
+import {rule2I} from './rule2I';
+
+describe('The function for rule 2I', () => {
+  let container: HTMLElement;
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('returns title attribute value if present', () => {
+    render(html` <div id="foo" title="Hello world"></div> `, container);
+    expect(rule2I(document.getElementById('foo')!)).toBe('Hello world');
+  });
+
+  it('returns null if title attribute is not present', () => {
+    render(html` <div id="foo"></div> `, container);
+    expect(rule2I(document.getElementById('foo')!)).toBe(null);
+  });
+
+  it('returns closest ancestor title attribute value', () => {
+    render(
+      html`
+        <div title="Hello world">
+          <div id="foo"></div>
+        </div>
+      `,
+      container
+    );
+    expect(rule2I(document.getElementById('foo')!)).toBe('Hello world');
+  });
+
+  it('returns placeholder for textual inputs if title not present', () => {
+    render(
+      html` <input id="foo" type="text" placeholder="Hello world" /> `,
+      container
+    );
+    expect(rule2I(document.getElementById('foo')!)).toBe('Hello world');
+  });
+
+  it('returns placeholder for textareas if title not present', () => {
+    render(
+      html` <textarea id="foo" placeholder="Hello world"></textarea> `,
+      container
+    );
+    expect(rule2I(document.getElementById('foo')!)).toBe('Hello world');
+  });
+
+  it('returns title with priority over placeholder', () => {
+    render(
+      html`
+        <textarea
+          id="foo"
+          placeholder="Goodbye world"
+          title="Hello world"
+        ></textarea>
+      `,
+      container
+    );
+    expect(rule2I(document.getElementById('foo')!)).toBe('Hello world');
+  });
+});


### PR DESCRIPTION
This rule handles tooltip `title` attributes for elements who have not been accepted to any other rule.

Something to double check here is the assumption that elements should inherit titles. It seems to [say this in the HTML spec](https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute) but is not implemented by Chrome (even though elements in chrome _do_ inherit tooltips).