### PR TITLE
Added a New Exported Function

### DIFF
--- a/src/accessible_name.ts
+++ b/src/accessible_name.ts
@@ -1,11 +1,19 @@
-import {computeTextAlternative} from './lib/compute_text_alternative';
+import {computeTextAlternative, Rule} from './lib/compute_text_alternative';
 
 /**
- * Main exported function for the library. Initialises traversal with an empty
- * context.
- * @param elem - The element whose accessible name will be calculated
- * @return - The accessible name for elem
+ * Compute the accessible name for a given HTMLElement.
+ * @param elem - The HTMLElement whose accessible name will be calculated.
  */
 export function getAccessibleName(elem: HTMLElement): string {
+  return computeTextAlternative(elem).name;
+}
+
+/**
+ * Get details surrounding the computation of the accessible name for a given HTMLElement
+ * @param elem - The HTMLElement whose accessible name will be calculated.
+ */
+export function getNameComputationDetails(
+  elem: HTMLElement
+): {name: string; nodesUsed: Set<Node>; rulesApplied: Set<Rule>} {
   return computeTextAlternative(elem);
 }

--- a/src/accessible_name.ts
+++ b/src/accessible_name.ts
@@ -1,4 +1,7 @@
-import {computeTextAlternative, Rule} from './lib/compute_text_alternative';
+import {
+  computeTextAlternative,
+  ComputationDetails,
+} from './lib/compute_text_alternative';
 
 /**
  * Compute the accessible name for a given HTMLElement.
@@ -14,6 +17,6 @@ export function getAccessibleName(elem: HTMLElement): string {
  */
 export function getNameComputationDetails(
   elem: HTMLElement
-): {name: string; nodesUsed: Set<Node>; rulesApplied: Set<Rule>} {
+): ComputationDetails {
   return computeTextAlternative(elem);
 }

--- a/src/lib/compute_text_alternative.ts
+++ b/src/lib/compute_text_alternative.ts
@@ -9,6 +9,11 @@ import {rule2G} from './rule2G';
 import {rule2I} from './rule2I';
 
 /**
+ * A reference to the rules outlined in the accname spec.
+ */
+export type Rule = '2A' | '2B' | '2C' | '2D' | '2E' | '2F' | '2G' | '2I';
+
+/**
  * @param node - The node whose text alternative will be calculated
  * @param  context - Additional information relevant to the text alternative
  *     computation for node. Optional paramater is 'getDefaultContext' by default.
@@ -17,49 +22,93 @@ import {rule2I} from './rule2I';
 export function computeTextAlternative(
   node: Node,
   context: Context = getDefaultContext()
-): string {
-  let result: string | null = '';
+): {name: string; nodesUsed: Set<Node>; rulesApplied: Set<Rule>} {
+  context.inherited.nodesUsed.add(node);
+  let result: string | null = null;
 
   result = rule2A(node, context);
   if (result !== null) {
-    return result;
+    context.inherited.rulesApplied.add('2A');
+    return {
+      name: result,
+      nodesUsed: context.inherited.nodesUsed,
+      rulesApplied: context.inherited.rulesApplied,
+    };
   }
 
   result = rule2B(node, context);
   if (result !== null) {
-    return result;
+    context.inherited.rulesApplied.add('2B');
+    return {
+      name: result,
+      nodesUsed: context.inherited.nodesUsed,
+      rulesApplied: context.inherited.rulesApplied,
+    };
   }
 
   result = rule2C(node, context);
   if (result !== null) {
-    return result;
+    context.inherited.rulesApplied.add('2C');
+    return {
+      name: result,
+      nodesUsed: context.inherited.nodesUsed,
+      rulesApplied: context.inherited.rulesApplied,
+    };
   }
 
   result = rule2D(node, context);
   if (result !== null) {
-    return result;
+    context.inherited.rulesApplied.add('2D');
+    return {
+      name: result,
+      nodesUsed: context.inherited.nodesUsed,
+      rulesApplied: context.inherited.rulesApplied,
+    };
   }
 
   result = rule2E(node, context);
   if (result !== null) {
-    return result;
+    context.inherited.rulesApplied.add('2E');
+    return {
+      name: result,
+      nodesUsed: context.inherited.nodesUsed,
+      rulesApplied: context.inherited.rulesApplied,
+    };
   }
 
   result = rule2F(node, context);
   if (result !== null) {
-    return result;
+    context.inherited.rulesApplied.add('2F');
+    return {
+      name: result,
+      nodesUsed: context.inherited.nodesUsed,
+      rulesApplied: context.inherited.rulesApplied,
+    };
   }
 
   result = rule2G(node);
   if (result !== null) {
-    return result;
+    context.inherited.rulesApplied.add('2G');
+    return {
+      name: result,
+      nodesUsed: context.inherited.nodesUsed,
+      rulesApplied: context.inherited.rulesApplied,
+    };
   }
 
   result = rule2I(node);
   if (result !== null) {
-    return result;
+    context.inherited.rulesApplied.add('2I');
+    return {
+      name: result,
+      nodesUsed: context.inherited.nodesUsed,
+      rulesApplied: context.inherited.rulesApplied,
+    };
   }
 
-  // If no result is found, the empty string is the text alternative
-  return '';
+  return {
+    name: '',
+    nodesUsed: context.inherited.nodesUsed,
+    rulesApplied: context.inherited.rulesApplied,
+  };
 }

--- a/src/lib/compute_text_alternative.ts
+++ b/src/lib/compute_text_alternative.ts
@@ -13,97 +13,54 @@ import {rule2I} from './rule2I';
  */
 export type Rule = '2A' | '2B' | '2C' | '2D' | '2E' | '2F' | '2G' | '2I';
 
+const ruleToImpl: {
+  [rule in Rule]: (node: Node, context: Context) => string | null;
+} = {
+  '2A': rule2A,
+  '2B': rule2B,
+  '2C': rule2C,
+  '2D': rule2D,
+  '2E': rule2E,
+  '2F': rule2F,
+  '2G': rule2G,
+  '2I': rule2I,
+};
+
+/**
+ * Provides details about the computation of some accessible name, such as
+ * the Nodes used and rules applied during computation.
+ */
+export interface ComputationDetails {
+  name: string;
+  nodesUsed: Set<Node>;
+  rulesApplied: Set<Rule>;
+}
+
 /**
  * @param node - The node whose text alternative will be calculated
  * @param  context - Additional information relevant to the text alternative
- *     computation for node. Optional paramater is 'getDefaultContext' by default.
+ * computation for node. Optional paramater is 'getDefaultContext' by default.
  * @return - The text alternative for node
  */
 export function computeTextAlternative(
   node: Node,
   context: Context = getDefaultContext()
-): {name: string; nodesUsed: Set<Node>; rulesApplied: Set<Rule>} {
+): ComputationDetails {
   context.inherited.nodesUsed.add(node);
-  let result: string | null = null;
 
-  result = rule2A(node, context);
-  if (result !== null) {
-    context.inherited.rulesApplied.add('2A');
-    return {
-      name: result,
-      nodesUsed: context.inherited.nodesUsed,
-      rulesApplied: context.inherited.rulesApplied,
-    };
-  }
-
-  result = rule2B(node, context);
-  if (result !== null) {
-    context.inherited.rulesApplied.add('2B');
-    return {
-      name: result,
-      nodesUsed: context.inherited.nodesUsed,
-      rulesApplied: context.inherited.rulesApplied,
-    };
-  }
-
-  result = rule2C(node, context);
-  if (result !== null) {
-    context.inherited.rulesApplied.add('2C');
-    return {
-      name: result,
-      nodesUsed: context.inherited.nodesUsed,
-      rulesApplied: context.inherited.rulesApplied,
-    };
-  }
-
-  result = rule2D(node, context);
-  if (result !== null) {
-    context.inherited.rulesApplied.add('2D');
-    return {
-      name: result,
-      nodesUsed: context.inherited.nodesUsed,
-      rulesApplied: context.inherited.rulesApplied,
-    };
-  }
-
-  result = rule2E(node, context);
-  if (result !== null) {
-    context.inherited.rulesApplied.add('2E');
-    return {
-      name: result,
-      nodesUsed: context.inherited.nodesUsed,
-      rulesApplied: context.inherited.rulesApplied,
-    };
-  }
-
-  result = rule2F(node, context);
-  if (result !== null) {
-    context.inherited.rulesApplied.add('2F');
-    return {
-      name: result,
-      nodesUsed: context.inherited.nodesUsed,
-      rulesApplied: context.inherited.rulesApplied,
-    };
-  }
-
-  result = rule2G(node);
-  if (result !== null) {
-    context.inherited.rulesApplied.add('2G');
-    return {
-      name: result,
-      nodesUsed: context.inherited.nodesUsed,
-      rulesApplied: context.inherited.rulesApplied,
-    };
-  }
-
-  result = rule2I(node);
-  if (result !== null) {
-    context.inherited.rulesApplied.add('2I');
-    return {
-      name: result,
-      nodesUsed: context.inherited.nodesUsed,
-      rulesApplied: context.inherited.rulesApplied,
-    };
+  // Try each rule sequentially on the target Node.
+  for (const [rule, impl] of Object.entries(ruleToImpl)) {
+    const result = impl(node, context);
+    // A rule has been applied if its implementation has
+    // returned a string.
+    if (result !== null) {
+      context.inherited.rulesApplied.add(<Rule>rule);
+      return {
+        name: result,
+        nodesUsed: context.inherited.nodesUsed,
+        rulesApplied: context.inherited.rulesApplied,
+      };
+    }
   }
 
   return {

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -1,5 +1,5 @@
 import {html, render} from 'lit-html';
-import {computeTextAlternative} from './compute_text_alternative';
+import {computeTextAlternative, Rule} from './compute_text_alternative';
 
 describe('The computeTextAlternative function', () => {
   let container: HTMLElement;
@@ -25,7 +25,7 @@ describe('The computeTextAlternative function', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(computeTextAlternative(elem!)).toBe('Hello world');
+    expect(computeTextAlternative(elem!).name).toBe('Hello world');
   });
 
   it("uses aria-labelledby references when computing 'name from content' nodes", () => {
@@ -39,7 +39,7 @@ describe('The computeTextAlternative function', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(computeTextAlternative(elem!)).toBe('Hello world');
+    expect(computeTextAlternative(elem!).name).toBe('Hello world');
   });
 
   it('prefers input value to aria-label for embedded controls', () => {
@@ -54,6 +54,16 @@ describe('The computeTextAlternative function', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(computeTextAlternative(elem!)).toBe('Say hello 5 times');
+    expect(computeTextAlternative(elem!).name).toBe('Say hello 5 times');
+  });
+
+  it('returns correct nodesUsed and rulesApplied sets for simple button input', () => {
+    render(html` <button id="foo">Hello world</button> `, container);
+    const elem = document.getElementById('foo')!;
+    expect(computeTextAlternative(elem)).toEqual({
+      name: 'Hello world',
+      nodesUsed: new Set<Node>([elem, elem.childNodes[0]]),
+      rulesApplied: new Set<Rule>(['2G', '2F']),
+    });
   });
 });

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -66,4 +66,21 @@ describe('The computeTextAlternative function', () => {
       rulesApplied: new Set<Rule>(['2G', '2F']),
     });
   });
+
+  it('returns correct nodesUsed and rulesApplied sets for aria-labelledby references', () => {
+    render(
+      html`
+        <div id="foo" aria-labelledby="bar">Hi</div>
+        <div id="bar">Hello world</div>
+      `,
+      container
+    );
+    const elem1 = document.getElementById('foo')!;
+    const elem2 = document.getElementById('bar')!;
+    expect(computeTextAlternative(elem1)).toEqual({
+      name: 'Hello world',
+      nodesUsed: new Set<Node>([elem1, elem2, elem2.childNodes[0]]),
+      rulesApplied: new Set<Rule>(['2B', '2F', '2G']),
+    });
+  });
 });

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,3 +1,5 @@
+import {Rule} from './compute_text_alternative';
+
 /**
  * This interface will be used to pass additional information
  * about the element whose name is being computed.
@@ -29,11 +31,24 @@ export interface Context {
     // may be considered equivalent.
     partOfName?: boolean;
     /**
-     * visitedNodes stores any nodes visited by rule 2F to
-     * ensure that any node is visited at most once. This
+     * visitedNodes stores any nodes visited recursively by rule 2F
+     * to ensure that any node is visited at most once. This
      * prevents infinite cycles during node traversal.
      */
     visitedNodes: Node[];
+
+    // TODO: Look into merging 'nodesUsed' and 'visitedNodes'
+
+    /**
+     * nodesUsed stores any Nodes used during the name computation
+     * algorithm, including the original target node.
+     */
+    nodesUsed: Set<Node>;
+    /**
+     * rulesApplied stores all Rules that were applied during the
+     * name computation algorithm.
+     */
+    rulesApplied: Set<Rule>;
   };
 }
 
@@ -44,6 +59,8 @@ export function getDefaultContext(): Context {
   return {
     inherited: {
       visitedNodes: [],
+      nodesUsed: new Set<Node>(),
+      rulesApplied: new Set<Rule>(),
     },
   };
 }

--- a/src/lib/rule2B.ts
+++ b/src/lib/rule2B.ts
@@ -54,7 +54,7 @@ export function rule2B(
       return computeTextAlternative(labelElem, {
         directLabelReference: true,
         inherited: context.inherited,
-      });
+      }).name;
     })
     .join(' ')
     .trim();

--- a/src/lib/rule2D.ts
+++ b/src/lib/rule2D.ts
@@ -47,7 +47,7 @@ export function rule2D(
       context.inherited.partOfName = true;
       return computeTextAlternative(captionElem, {
         inherited: context.inherited,
-      });
+      }).name;
     }
   }
 
@@ -59,7 +59,7 @@ export function rule2D(
       context.inherited.partOfName = true;
       return computeTextAlternative(figcaptionElem, {
         inherited: context.inherited,
-      });
+      }).name;
     }
   }
 
@@ -70,7 +70,7 @@ export function rule2D(
       context.inherited.partOfName = true;
       return computeTextAlternative(legendElem, {
         inherited: context.inherited,
-      });
+      }).name;
     }
   }
 
@@ -155,11 +155,12 @@ function getTextIfLabelled(elem: HTMLElement, context: Context): string | null {
   });
 
   const textAlternative = labelElems
-    .map(labelElem =>
-      computeTextAlternative(labelElem, {
-        directLabelReference: true,
-        inherited: context.inherited,
-      })
+    .map(
+      labelElem =>
+        computeTextAlternative(labelElem, {
+          directLabelReference: true,
+          inherited: context.inherited,
+        }).name
     )
     .filter(text => text !== '')
     .join(' ');

--- a/src/lib/rule2E.ts
+++ b/src/lib/rule2E.ts
@@ -92,7 +92,7 @@ function getValueIfComboboxOrListbox(
       .map(optionElem => {
         return computeTextAlternative(optionElem, {
           inherited: context.inherited,
-        });
+        }).name;
       })
       .filter(alternativeText => alternativeText !== '')
       .join(' ');

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -212,7 +212,7 @@ export function rule2F(
 
       const textAlterantive = computeTextAlternative(childNode, {
         inherited: context.inherited,
-      });
+      }).name;
 
       textAlterantives.push(textAlterantive);
     }


### PR DESCRIPTION
- Added a new exported function `getNameComputationDetails()` that returns sets of `nodesUsed` and `rulesApplied` as well as the accessible name for a given `HTMLElement`.
- Modified the `Context` interface to include these new `nodesUsed` and `rulesApplied` properties, which are both populated as the algorithm traverses DOM Nodes and applied rules from the spec in `computeTextAlternative()`.