### PR TITLE
Added live import for AccName library

### DIFF
--- a/validation/compare.ts
+++ b/validation/compare.ts
@@ -23,10 +23,7 @@ import axe from 'axe-core';
   */
   // Compare on snippet
   /*
-  const USER_INPUT_HTML_SNIPPET = `
-    <div accnamecomparisontarget aria-labelledby="foo">Hello world</div>
-    <div id="foo">Hi planet</div>
-  `;
+  const USER_INPUT_HTML_SNIPPET = `<div accnamecomparisontarget>Hello world</div>`;
   const result = await runHTMLSnippetComparison(USER_INPUT_HTML_SNIPPET);
   console.log(result);
   */
@@ -208,20 +205,15 @@ async function runComparison(
   const agreementGroups = Object.values(agreementMap);
 
   // 1 agreement group --> all implementations agree.
-
   if (agreementGroups.length === 1) {
     return {disagrees: false, accnames: accnames};
   }
 
   const category: Category = {agreement: agreementGroups};
 
-  const rulesApplied = (await page.evaluate(
-    `
+  const rulesApplied = (await page.evaluate(`
     let ruleSet = accname.getNameComputationDetails(document.querySelector('${nodeRef.selector}')).rulesApplied;
-    Array.from(ruleSet);
-    `
-  )) as string[];
-
+    Array.from(ruleSet);`)) as string[];
   if (rulesApplied.length > 0) {
     category.rules = rulesApplied;
   }

--- a/validation/html_used.ts
+++ b/validation/html_used.ts
@@ -22,11 +22,12 @@ export async function getHTMLUsed(
   const accnameNodeArrayLength = await page.evaluate(`
     const nodeSet = accname.getNameComputationDetails(document.querySelector('${nodeRef.selector}')).nodesUsed;
     const nodeArray = Array.from(nodeSet);
-    nodeArray.length;`
-  );
+    nodeArray.length;`);
   // Make an array containing an ElementHandle for each Node in nodeArray
-  const accnameHandles = await Promise.all([...Array(accnameNodeArrayLength).keys()].map((i) => 
-    page.evaluateHandle(`nodeArray[${i}]`)
+  const accnameHandles = (await Promise.all(
+    [...Array(accnameNodeArrayLength).keys()].map(i =>
+      page.evaluateHandle(`nodeArray[${i}]`)
+    )
   )) as ElementHandle<Element>[];
   const htmlUsedByAccname = await getHTMLFromHandles(accnameHandles, page);
 
@@ -43,7 +44,6 @@ async function getHTMLFromHandles(
   handles: ElementHandle<Element>[],
   page: Page
 ): Promise<string> {
-  
   // Get the outerHTML of the nodes used by Chrome
   const htmlString = await page.evaluate((...nodes) => {
     // Sort nodes by DOM order


### PR DESCRIPTION
- Accname library is now imported from the [bundle branch](https://github.com/googleinterns/accessible-name/tree/bundle) which contains a bundle of the code most recently pushed to the github repo.
- `getHTMLFromHandles()` function added -- this now calculates HTML snippets for both Chrome and Accname implementations, as opposed to just Chrome.