### PR TITLE
Fix for issues #33 #19

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -658,10 +658,10 @@ var accname = (function (exports) {
         const accumulatedText = textAlterantives
             .filter(textAlterantive => textAlterantive !== '')
             .join(' ');
-        const result = (cssBeforeContent + accumulatedText + cssAfterContent).trim();
         // #SPEC_ASSUMPTION (F.2) : that CSS generated content should be
         // concatenated to accumulatedText
-        return result === '' ? null : result;
+        const result = (cssBeforeContent + accumulatedText + cssAfterContent).trim();
+        return result || null;
     }
 
     /**

--- a/bundle.js
+++ b/bundle.js
@@ -658,9 +658,10 @@ var accname = (function (exports) {
         const accumulatedText = textAlterantives
             .filter(textAlterantive => textAlterantive !== '')
             .join(' ');
+        const result = (cssBeforeContent + accumulatedText + cssAfterContent).trim();
         // #SPEC_ASSUMPTION (F.2) : that CSS generated content should be
         // concatenated to accumulatedText
-        return (cssBeforeContent + accumulatedText + cssAfterContent).trim();
+        return result === '' ? null : result;
     }
 
     /**

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -83,4 +83,26 @@ describe('The computeTextAlternative function', () => {
       rulesApplied: new Set<Rule>(['2B', '2F', '2G']),
     });
   });
+
+  it('check title attribute for name when subtree is empty', () => {
+    render(
+      html` <input type="checkbox" title="Hello world" id="foo" /> `,
+      container
+    );
+    const elem = document.getElementById('foo')!;
+    expect(computeTextAlternative(elem).name).toEqual('Hello world');
+  });
+
+  it('check title attribute for name when subtree is hidden', () => {
+    render(
+      html`
+        <button title="Hello world" id="foo">
+          <div aria-hidden="true">Invisible text</div>
+        </button>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo')!;
+    expect(computeTextAlternative(elem).name).toEqual('Hello world');
+  });
 });

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -226,9 +226,9 @@ export function rule2F(
     .filter(textAlterantive => textAlterantive !== '')
     .join(' ');
 
-  const result = (cssBeforeContent + accumulatedText + cssAfterContent).trim();
-
   // #SPEC_ASSUMPTION (F.2) : that CSS generated content should be
   // concatenated to accumulatedText
-  return result === '' ? null : result;
+  const result = (cssBeforeContent + accumulatedText + cssAfterContent).trim();
+
+  return result || null;
 }

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -226,7 +226,9 @@ export function rule2F(
     .filter(textAlterantive => textAlterantive !== '')
     .join(' ');
 
+  const result = (cssBeforeContent + accumulatedText + cssAfterContent).trim();
+
   // #SPEC_ASSUMPTION (F.2) : that CSS generated content should be
   // concatenated to accumulatedText
-  return (cssBeforeContent + accumulatedText + cssAfterContent).trim();
+  return result === '' ? null : result;
 }

--- a/validation/src/static/scripts/case.ts
+++ b/validation/src/static/scripts/case.ts
@@ -51,7 +51,7 @@
   const inputSnippet = res.context.inputSnippet ?? null;
   if (inputSnippet) {
     contextHeading.innerText = 'Input HTML Snippet';
-    inputCode.innerHTML = inputSnippet.replace(/</g, '&lt;');;
+    inputCode.innerHTML = inputSnippet.replace(/</g, '&lt;');
   }
 
   const targetUrl = res.context.url ?? null;


### PR DESCRIPTION
Fix for issues #33, #19.

- Now `accname` will check for `title` if 2F returns empty string (i.e. if 2F can't compute an accessible name using its subtree)