### PR TITLE
CSS content only added if textual

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -614,14 +614,11 @@ var accname = (function (exports) {
     function getCssContent(elem, pseudoElementName) {
         const cssContent = window.getComputedStyle(elem, pseudoElementName)
             .content;
-        if (cssContent === 'none') {
-            return '';
-        }
-        else {
-            // slicing off unnecessary double quotes (")
-            // from either end of the string.
+        // <string> CSS content identified by surrounding double-quotes
+        if (cssContent[0] === '"' && cssContent[cssContent.length - 1] === '"') {
             return cssContent.slice(1, -1);
         }
+        return '';
     }
     /**
      * Implementation of rule 2F

--- a/bundle.js
+++ b/bundle.js
@@ -614,8 +614,11 @@ var accname = (function (exports) {
     function getCssContent(elem, pseudoElementName) {
         const cssContent = window.getComputedStyle(elem, pseudoElementName)
             .content;
-        // <string> CSS content identified by surrounding double-quotes
-        if (cssContent[0] === '"' && cssContent[cssContent.length - 1] === '"') {
+        // <string> CSS content identified by surrounding quotes
+        // see: https://developer.mozilla.org/en-US/docs/Web/CSS/content
+        // and: https://developer.mozilla.org/en-US/docs/Web/CSS/string
+        if ((cssContent[0] === '"' && cssContent[cssContent.length - 1] === '"') ||
+            (cssContent[0] === "'" && cssContent[cssContent.length - 1] === "'")) {
             return cssContent.slice(1, -1);
         }
         return '';

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -172,8 +172,13 @@ function rule2FCondition(elem: HTMLElement, context: Context): boolean {
 function getCssContent(elem: HTMLElement, pseudoElementName: string): string {
   const cssContent: string = window.getComputedStyle(elem, pseudoElementName)
     .content;
-  // <string> CSS content identified by surrounding double-quotes
-  if (cssContent[0] === '"' && cssContent[cssContent.length - 1] === '"') {
+  // <string> CSS content identified by surrounding quotes
+  // see: https://developer.mozilla.org/en-US/docs/Web/CSS/content
+  // and: https://developer.mozilla.org/en-US/docs/Web/CSS/string
+  if (
+    (cssContent[0] === '"' && cssContent[cssContent.length - 1] === '"') ||
+    (cssContent[0] === "'" && cssContent[cssContent.length - 1] === "'")
+  ) {
     return cssContent.slice(1, -1);
   }
   return '';

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -172,13 +172,11 @@ function rule2FCondition(elem: HTMLElement, context: Context): boolean {
 function getCssContent(elem: HTMLElement, pseudoElementName: string): string {
   const cssContent: string = window.getComputedStyle(elem, pseudoElementName)
     .content;
-  if (cssContent === 'none') {
-    return '';
-  } else {
-    // slicing off unnecessary double quotes (")
-    // from either end of the string.
+  // <string> CSS content identified by surrounding double-quotes
+  if (cssContent[0] === '"' && cssContent[cssContent.length - 1] === '"') {
     return cssContent.slice(1, -1);
   }
+  return '';
 }
 
 /**

--- a/src/lib/rule2F_test.ts
+++ b/src/lib/rule2F_test.ts
@@ -74,6 +74,26 @@ describe('The function for rule 2F', () => {
     expect(rule2F(elem!, context)).toBe('Helloworld!');
   });
 
+  it("doesn't include non-textual CSS content", () => {
+    render(
+      html`
+        <style>
+          #foo:before {
+            url("a/url/to/some/image");
+          }
+        </style>
+        <div id="foo">
+          Hello world
+        </div>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.directLabelReference = true;
+    expect(rule2F(elem!, context)).toBe('Hello world');
+  });
+
   it("doesn't visit the same node twice during a recursive traversal", () => {
     render(
       html`

--- a/src/lib/rule2F_test.ts
+++ b/src/lib/rule2F_test.ts
@@ -79,7 +79,7 @@ describe('The function for rule 2F', () => {
       html`
         <style>
           #foo:before {
-            url("a/url/to/some/image");
+            content: url('a/url/to/some/image');
           }
         </style>
         <div id="foo">


### PR DESCRIPTION
Fix for #40 

- CSS content should be added to the accessible name string only if it is textual content.
- This PR adds a check ensuring that CSS content is only added if it is textual.

Sources:
https://developer.mozilla.org/en-US/docs/Web/CSS/content
https://developer.mozilla.org/en-US/docs/Web/CSS/string