### PR TITLE
Handling Explicit Combobox

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -190,7 +190,7 @@ var accname = (function (exports) {
         // chosen option is the input value.
         if (node instanceof HTMLInputElement &&
             TEXT_INPUT_TYPES.includes(node.type) &&
-            node.hasAttribute('list')) {
+            (node.hasAttribute('list') || nodeRole === 'combobox')) {
             return node.value;
         }
         // Text alternative for elems of role 'listbox' and 'combobox'

--- a/src/lib/rule2E.ts
+++ b/src/lib/rule2E.ts
@@ -63,7 +63,7 @@ function getValueIfComboboxOrListbox(
   if (
     node instanceof HTMLInputElement &&
     TEXT_INPUT_TYPES.includes(node.type) &&
-    node.hasAttribute('list')
+    (node.hasAttribute('list') || nodeRole === 'combobox')
   ) {
     return node.value;
   }

--- a/src/lib/rule2E_test.ts
+++ b/src/lib/rule2E_test.ts
@@ -53,6 +53,17 @@ describe('The function for rule 2E', () => {
     expect(rule2E(elem!, context)).toBe('hello');
   });
 
+  it('returns text content for inputs explicitly defined as comboboxes', () => {
+    render(
+      html`<input id="foo" type="text" role="combobox" value="hello" />`,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.inherited.partOfName = true;
+    expect(rule2E(elem!, context)).toBe('hello');
+  });
+
   it('returns text alternative of selected option in select element', () => {
     render(
       html`


### PR DESCRIPTION
See #36 

`accname` currently fails the following WPT: [name_heading-combobox-focusable-alternative-manual](http://wpt.live/accname/name_heading-combobox-focusable-alternative-manual.html).

This PR adds a check for explicitly defined comboboxes, as well as a test to ensure that they are now handled correctly.