### PR TITLE
Aria-owned Nodes

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -643,7 +643,7 @@ var accname = (function (exports) {
         const ariaOwnedNodeIds = node.getAttribute('aria-owns');
         if (ariaOwnedNodeIds) {
             for (const idref of ariaOwnedNodeIds.split(' ')) {
-                const referencedNode = document.querySelector(`[id='${idref}']`);
+                const referencedNode = document.getElementById(idref);
                 if (referencedNode) {
                     a11yChildNodes.push(referencedNode);
                 }

--- a/bundle.js
+++ b/bundle.js
@@ -638,10 +638,19 @@ var accname = (function (exports) {
         if (!rule2FCondition(node, context)) {
             return null;
         }
-        const cssBeforeContent = getCssContent(node, ':before');
-        const cssAfterContent = getCssContent(node, ':after');
+        const a11yChildNodes = Array.from(node.childNodes);
+        // Include any aria-owned Nodes in the list of 'child nodes'
+        const ariaOwnedNodeIds = node.getAttribute('aria-owns');
+        if (ariaOwnedNodeIds) {
+            for (const idref of ariaOwnedNodeIds.split(' ')) {
+                const referencedNode = document.querySelector(`[id='${idref}']`);
+                if (referencedNode) {
+                    a11yChildNodes.push(referencedNode);
+                }
+            }
+        }
         const textAlterantives = [];
-        for (const childNode of node.childNodes) {
+        for (const childNode of a11yChildNodes) {
             if (!context.inherited.visitedNodes.includes(childNode)) {
                 context.inherited.visitedNodes.push(childNode);
                 context.inherited.partOfName = true;
@@ -658,6 +667,8 @@ var accname = (function (exports) {
         const accumulatedText = textAlterantives
             .filter(textAlterantive => textAlterantive !== '')
             .join(' ');
+        const cssBeforeContent = getCssContent(node, ':before');
+        const cssAfterContent = getCssContent(node, ':after');
         // #SPEC_ASSUMPTION (F.2) : that CSS generated content should be
         // concatenated to accumulatedText
         const result = (cssBeforeContent + accumulatedText + cssAfterContent).trim();

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -107,13 +107,13 @@ describe('The computeTextAlternative function', () => {
   });
 
   // http://wpt.live/accname/name_file-label-owned-combobox-manual.html
-  it("doesn't visit the same node twice during a recursive traversal", () => {
+  it('includes aria-owned nodes in the subtree of the current node', () => {
     render(
       html`
         <input type="file" id="test" />
-        <label for="test"
-          >Flash <span aria-owns="id1">the screen</span> times.</label
-        >
+        <label for="test">
+          Flash <span aria-owns="id1">the screen</span> times.
+        </label>
         <div id="id1">
           <div role="combobox">
             <div role="textbox"></div>
@@ -132,13 +132,13 @@ describe('The computeTextAlternative function', () => {
   });
 
   // http://wpt.live/accname/name_file-label-owned-combobox-owned-listbox-manual.html
-  it("doesn't visit the same node twice during a recursive traversal", () => {
+  it('allows aria-owned nodes to be chained together across multiple nodes', () => {
     render(
       html`
         <input type="file" id="test" />
-        <label for="test"
-          >Flash <span aria-owns="id1">the screen</span> times.</label
-        >
+        <label for="test">
+          Flash <span aria-owns="id1">the screen</span> times.
+        </label>
         <div>
           <div id="id1" role="combobox" aria-owns="id2">
             <div role="textbox"></div>

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -105,4 +105,56 @@ describe('The computeTextAlternative function', () => {
     const elem = document.getElementById('foo')!;
     expect(computeTextAlternative(elem).name).toEqual('Hello world');
   });
+
+  // http://wpt.live/accname/name_file-label-owned-combobox-manual.html
+  it("doesn't visit the same node twice during a recursive traversal", () => {
+    render(
+      html`
+        <input type="file" id="test" />
+        <label for="test"
+          >Flash <span aria-owns="id1">the screen</span> times.</label
+        >
+        <div id="id1">
+          <div role="combobox">
+            <div role="textbox"></div>
+            <ul role="listbox" style="list-style-type: none;">
+              <li role="option" aria-selected="true">1</li>
+              <li role="option">2</li>
+              <li role="option">3</li>
+            </ul>
+          </div>
+        </div>
+      `,
+      container
+    );
+    const elem = document.getElementById('test')!;
+    expect(computeTextAlternative(elem).name).toBe('Flash the screen 1 times.');
+  });
+
+  // http://wpt.live/accname/name_file-label-owned-combobox-owned-listbox-manual.html
+  it("doesn't visit the same node twice during a recursive traversal", () => {
+    render(
+      html`
+        <input type="file" id="test" />
+        <label for="test"
+          >Flash <span aria-owns="id1">the screen</span> times.</label
+        >
+        <div>
+          <div id="id1" role="combobox" aria-owns="id2">
+            <div role="textbox"></div>
+          </div>
+        </div>
+        <div>
+          <ul id="id2" role="listbox" style="list-style-type: none;">
+            <li role="option">1</li>
+            <li role="option" aria-selected="true">2</li>
+            <li role="option">3</li>
+          </ul>
+        </div>
+      `,
+      container
+    );
+    const elem = document.getElementById('test')!;
+    expect(computeTextAlternative(elem).name).toBe('Flash the screen 2 times.');
+  });
 });

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -210,7 +210,7 @@ export function rule2F(
   const ariaOwnedNodeIds = node.getAttribute('aria-owns');
   if (ariaOwnedNodeIds) {
     for (const idref of ariaOwnedNodeIds.split(' ')) {
-      const referencedNode = document.querySelector(`[id='${idref}']`);
+      const referencedNode = document.getElementById(idref);
       if (referencedNode) {
         a11yChildNodes.push(referencedNode);
       }

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -204,11 +204,21 @@ export function rule2F(
     return null;
   }
 
-  const cssBeforeContent = getCssContent(node, ':before');
-  const cssAfterContent = getCssContent(node, ':after');
+  const a11yChildNodes = Array.from(node.childNodes);
+
+  // Include any aria-owned Nodes in the list of 'child nodes'
+  const ariaOwnedNodeIds = node.getAttribute('aria-owns');
+  if (ariaOwnedNodeIds) {
+    for (const idref of ariaOwnedNodeIds.split(' ')) {
+      const referencedNode = document.querySelector(`[id='${idref}']`);
+      if (referencedNode) {
+        a11yChildNodes.push(referencedNode);
+      }
+    }
+  }
 
   const textAlterantives: string[] = [];
-  for (const childNode of node.childNodes) {
+  for (const childNode of a11yChildNodes) {
     if (!context.inherited.visitedNodes.includes(childNode)) {
       context.inherited.visitedNodes.push(childNode);
       context.inherited.partOfName = true;
@@ -228,6 +238,9 @@ export function rule2F(
   const accumulatedText = textAlterantives
     .filter(textAlterantive => textAlterantive !== '')
     .join(' ');
+
+  const cssBeforeContent = getCssContent(node, ':before');
+  const cssAfterContent = getCssContent(node, ':after');
 
   // #SPEC_ASSUMPTION (F.2) : that CSS generated content should be
   // concatenated to accumulatedText


### PR DESCRIPTION
- `accname` wasn't taking `aria-own`ed nodes into account in step 2F, causing it to fail WPTs such as [name_file-label-owned-combobox-manual](http://wpt.live/accname/name_file-label-owned-combobox-manual.html) and [name_file-label-owned-combobox-owned-listbox-manual](http://wpt.live/accname/name_file-label-owned-combobox-owned-listbox-manual.html).
- As of this PR, `accname` traverses nodes referenced by `aria-owns` in order after nodes that are direct DOM descendants of the `current node`.

Closes #35 