### PR TITLE
Added Check for 'forbids name from content'

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -666,7 +666,7 @@ var accname = (function (exports) {
      * @return - whether or not rule 2Fs condition has been satisfied
      */
     function allowsNameFromContent(elem, context) {
-        // focasable elements should allow name from content.
+        // focusable elements should allow name from content.
         if (matchesRole(elem, NEVER_NAME_FROM_CONTENT) &&
             elem.hasAttribute('tabindex')) {
             return true;

--- a/bundle.js
+++ b/bundle.js
@@ -489,7 +489,7 @@ var accname = (function (exports) {
      * to their implicit aria roles.
      * (https://www.w3.org/TR/html-aria/#docconformance)
      */
-    const NAME_FROM_CONTENT_ELEM_NODE_NAME = [
+    const NAME_FROM_CONTENT_TAGS = [
         'h1',
         'h2',
         'h3',
@@ -575,12 +575,96 @@ var accname = (function (exports) {
             return true;
         }
         const elemNodeName = elem.nodeName.toLowerCase();
-        if (NAME_FROM_CONTENT_ELEM_NODE_NAME.includes(elemNodeName)) {
+        if (NAME_FROM_CONTENT_TAGS.includes(elemNodeName)) {
             return true;
         }
         const nameFromContentFunction = getFunctionCalculatingAllowsNameFromContent(elemNodeName);
         if (nameFromContentFunction) {
             return nameFromContentFunction(elem);
+        }
+        return false;
+    }
+    // See https://lists.w3.org/Archives/Public/public-aria/2017Jun/0057.html
+    // for discussion of roles & tags that forbid name from content.
+    const NO_NAME_FROM_CONTENT_ROLES = [
+        'application',
+        'alert',
+        'log',
+        'marquee',
+        'timer',
+        'alertdialog',
+        'dialog',
+        'banner',
+        'complementary',
+        'form',
+        'main',
+        'navigation',
+        'region',
+        'search',
+        'article',
+        'document',
+        'feed',
+        'figure',
+        'img',
+        'math',
+        'toolbar',
+        'menu',
+        'menubar',
+        'grid',
+        'listbox',
+        'radiogroup',
+        'textbox',
+        'searchbox',
+        'spinbutton',
+        'scrollbar',
+        'slider',
+        'tablist',
+        'tabpanel',
+        'tree',
+        'treegrid',
+        'separator',
+        'rowgroup',
+        'group',
+    ];
+    const NO_NAME_FROM_CONTENT_TAGS = [
+        'article',
+        'aside',
+        'body',
+        'select',
+        'datalist',
+        'optgroup',
+        'dialog',
+        'figure',
+        'footer',
+        'form',
+        'header',
+        'hr',
+        'img',
+        'textarea',
+        'input',
+        'main',
+        'math',
+        'menu',
+        'nav',
+        'section',
+        'thead',
+        'tbody',
+        'tfoot',
+        'fieldset',
+    ];
+    /**
+     * Checks if 'elem' is forbidden from allowing 'name from content'
+     * @param elem - element whose text alternative is being computed
+     */
+    function forbidsNameFromContent(elem) {
+        var _a, _b;
+        const explicitRole = (_b = (_a = elem.getAttribute('role')) === null || _a === void 0 ? void 0 : _a.trim().toLowerCase()) !== null && _b !== void 0 ? _b : '';
+        if (NO_NAME_FROM_CONTENT_ROLES.includes(explicitRole)) {
+            return true;
+        }
+        const elemNodeName = elem.nodeName.toLowerCase();
+        if (NO_NAME_FROM_CONTENT_TAGS.includes(elemNodeName)) {
+            return true;
         }
         return false;
     }
@@ -592,6 +676,9 @@ var accname = (function (exports) {
      * @return - whether or not rule 2Fs condition has been satisfied
      */
     function rule2FCondition(elem, context) {
+        if (forbidsNameFromContent(elem)) {
+            return false;
+        }
         if (allowsNameFromContent(elem)) {
             return true;
         }

--- a/bundle.js
+++ b/bundle.js
@@ -667,7 +667,8 @@ var accname = (function (exports) {
      */
     function allowsNameFromContent(elem, context) {
         // focasable elements should allow name from content.
-        if (elem.hasAttribute('tabindex')) {
+        if (matchesRole(elem, NEVER_NAME_FROM_CONTENT) &&
+            elem.hasAttribute('tabindex')) {
             return true;
         }
         // The terms 'list 1', 'list 2', 'list 3' are used in reference

--- a/bundle.js
+++ b/bundle.js
@@ -666,11 +666,6 @@ var accname = (function (exports) {
      * @return - whether or not rule 2Fs condition has been satisfied
      */
     function allowsNameFromContent(elem, context) {
-        // focusable elements should allow name from content.
-        if (matchesRole(elem, NEVER_NAME_FROM_CONTENT) &&
-            elem.hasAttribute('tabindex')) {
-            return true;
-        }
         // The terms 'list 1', 'list 2', 'list 3' are used in reference
         // to the following thread: see: https://lists.w3.org/Archives/Public/public-aria/2017Jun/0057.html
         // Handles list 3 roles
@@ -683,7 +678,7 @@ var accname = (function (exports) {
         }
         // Handles list 2 roles
         if (matchesRole(elem, NEVER_NAME_FROM_CONTENT)) {
-            return false;
+            return elem.hasAttribute('tabindex');
         }
         // Handles list 1 roles
         if (matchesRole(elem, ALWAYS_NAME_FROM_CONTENT)) {

--- a/src/lib/allowsNameFromContent_test.ts
+++ b/src/lib/allowsNameFromContent_test.ts
@@ -148,8 +148,11 @@ describe('The function allowsNameFromContent', () => {
     expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(false);
   });
 
-  it('returns true for elements that are focusable', () => {
-    render(html` <div id="foo" tabindex="0">Hello world</div> `, container);
+  it('returns true for elements in NEVER_NFC that are focusable', () => {
+    render(
+      html` <article id="foo" tabindex="0">Hello world</article> `,
+      container
+    );
     const elem = document.getElementById('foo');
     expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });

--- a/src/lib/allowsNameFromContent_test.ts
+++ b/src/lib/allowsNameFromContent_test.ts
@@ -1,9 +1,9 @@
 import {html, render} from 'lit-html';
 import {TEST_ONLY} from './rule2F';
 
-const {allowsNameFromContent} = TEST_ONLY;
+const {roleAllowsNameFromContent} = TEST_ONLY;
 
-describe('The function allowsNameFromContent', () => {
+describe('The function roleAllowsNameFromContent', () => {
   let container: HTMLElement;
   beforeEach(() => {
     container = document.createElement('div');
@@ -24,7 +24,7 @@ describe('The function allowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(true);
+    expect(roleAllowsNameFromContent(elem!)).toBe(true);
   });
 
   it('returns false for roles that do not allow name from content', () => {
@@ -37,7 +37,7 @@ describe('The function allowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(false);
+    expect(roleAllowsNameFromContent(elem!)).toBe(false);
   });
 
   it('returns true for semantic html elements that imply a role that allows name from content', () => {
@@ -50,7 +50,7 @@ describe('The function allowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(true);
+    expect(roleAllowsNameFromContent(elem!)).toBe(true);
   });
 
   it('returns true for td elements if they are within a table', () => {
@@ -63,7 +63,7 @@ describe('The function allowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(true);
+    expect(roleAllowsNameFromContent(elem!)).toBe(true);
   });
 
   it('returns true for th elements if they are within a table', () => {
@@ -76,13 +76,13 @@ describe('The function allowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(true);
+    expect(roleAllowsNameFromContent(elem!)).toBe(true);
   });
 
   it('returns false for option elements if they are not within a datalist or select', () => {
     render(html` <option id="foo"></option> `, container);
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(false);
+    expect(roleAllowsNameFromContent(elem!)).toBe(false);
   });
 
   it('returns true for option elements if they are within a select', () => {
@@ -95,7 +95,7 @@ describe('The function allowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(true);
+    expect(roleAllowsNameFromContent(elem!)).toBe(true);
   });
 
   it('returns true for option elements if they are within a datalist', () => {
@@ -108,60 +108,60 @@ describe('The function allowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(true);
+    expect(roleAllowsNameFromContent(elem!)).toBe(true);
   });
 
   it('returns true for inputs with a type that allows name from content', () => {
     render(html` <input id="foo" type="button" /> `, container);
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(true);
+    expect(roleAllowsNameFromContent(elem!)).toBe(true);
   });
 
   it('returns false for inputs whose type does not allow name from content', () => {
     render(html` <input id="foo" type="color" /> `, container);
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(false);
+    expect(roleAllowsNameFromContent(elem!)).toBe(false);
   });
 
   it('returns true for links if they have a href attribute', () => {
     render(html` <a id="foo" href="#"></a> `, container);
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(true);
+    expect(roleAllowsNameFromContent(elem!)).toBe(true);
   });
 
   it('returns false for links if they do not have a href attribute', () => {
     render(html` <a id="foo"></a> `, container);
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(false);
+    expect(roleAllowsNameFromContent(elem!)).toBe(false);
   });
 
   it('returns true for area elements if they have a href attribute', () => {
     render(html` <area id="foo" href="#"></area> `, container);
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(true);
+    expect(roleAllowsNameFromContent(elem!)).toBe(true);
   });
 
   it('returns false for area elements if they do not have a href attribute', () => {
     render(html` <area id="foo"></area> `, container);
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(false);
+    expect(roleAllowsNameFromContent(elem!)).toBe(false);
   });
 
   it('returns true for link elements if they have a href attribute', () => {
     render(html` <link id="foo" href="#"></link> `, container);
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(true);
+    expect(roleAllowsNameFromContent(elem!)).toBe(true);
   });
 
   it('returns false for link elements if they do not have a href attribute', () => {
     render(html` <link id="foo"></link> `, container);
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(false);
+    expect(roleAllowsNameFromContent(elem!)).toBe(false);
   });
 
   it('returns false for input elements if they do not have a type attribute', () => {
     render(html` <input id="foo"></link> `, container);
     const elem = document.getElementById('foo');
-    expect(allowsNameFromContent(elem!)).toBe(false);
+    expect(roleAllowsNameFromContent(elem!)).toBe(false);
   });
 });

--- a/src/lib/allowsNameFromContent_test.ts
+++ b/src/lib/allowsNameFromContent_test.ts
@@ -1,9 +1,10 @@
 import {html, render} from 'lit-html';
+import {getDefaultContext} from './context';
 import {TEST_ONLY} from './rule2F';
 
-const {roleAllowsNameFromContent} = TEST_ONLY;
+const {allowsNameFromContent} = TEST_ONLY;
 
-describe('The function roleAllowsNameFromContent', () => {
+describe('The function allowsNameFromContent', () => {
   let container: HTMLElement;
   beforeEach(() => {
     container = document.createElement('div');
@@ -24,7 +25,7 @@ describe('The function roleAllowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(true);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });
 
   it('returns false for roles that do not allow name from content', () => {
@@ -37,7 +38,7 @@ describe('The function roleAllowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(false);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(false);
   });
 
   it('returns true for semantic html elements that imply a role that allows name from content', () => {
@@ -50,7 +51,7 @@ describe('The function roleAllowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(true);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });
 
   it('returns true for td elements if they are within a table', () => {
@@ -63,7 +64,7 @@ describe('The function roleAllowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(true);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });
 
   it('returns true for th elements if they are within a table', () => {
@@ -76,13 +77,13 @@ describe('The function roleAllowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(true);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });
 
   it('returns false for option elements if they are not within a datalist or select', () => {
     render(html` <option id="foo"></option> `, container);
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(false);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(false);
   });
 
   it('returns true for option elements if they are within a select', () => {
@@ -95,7 +96,7 @@ describe('The function roleAllowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(true);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });
 
   it('returns true for option elements if they are within a datalist', () => {
@@ -108,60 +109,48 @@ describe('The function roleAllowsNameFromContent', () => {
       container
     );
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(true);
-  });
-
-  it('returns true for inputs with a type that allows name from content', () => {
-    render(html` <input id="foo" type="button" /> `, container);
-    const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(true);
-  });
-
-  it('returns false for inputs whose type does not allow name from content', () => {
-    render(html` <input id="foo" type="color" /> `, container);
-    const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(false);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });
 
   it('returns true for links if they have a href attribute', () => {
     render(html` <a id="foo" href="#"></a> `, container);
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(true);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });
 
   it('returns false for links if they do not have a href attribute', () => {
     render(html` <a id="foo"></a> `, container);
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(false);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(false);
   });
 
   it('returns true for area elements if they have a href attribute', () => {
     render(html` <area id="foo" href="#"></area> `, container);
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(true);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });
 
   it('returns false for area elements if they do not have a href attribute', () => {
     render(html` <area id="foo"></area> `, container);
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(false);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(false);
   });
 
   it('returns true for link elements if they have a href attribute', () => {
     render(html` <link id="foo" href="#"></link> `, container);
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(true);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });
 
   it('returns false for link elements if they do not have a href attribute', () => {
     render(html` <link id="foo"></link> `, container);
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(false);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(false);
   });
 
-  it('returns false for input elements if they do not have a type attribute', () => {
-    render(html` <input id="foo"></link> `, container);
+  it('returns true for elements that are focusable', () => {
+    render(html` <div id="foo" tabindex="0">Hello world</div> `, container);
     const elem = document.getElementById('foo');
-    expect(roleAllowsNameFromContent(elem!)).toBe(false);
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });
 });

--- a/src/lib/allowsNameFromContent_test.ts
+++ b/src/lib/allowsNameFromContent_test.ts
@@ -156,4 +156,10 @@ describe('The function allowsNameFromContent', () => {
     const elem = document.getElementById('foo');
     expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(true);
   });
+
+  it('returns false for elements in NEVER_NFC that are not focusable', () => {
+    render(html` <article id="foo">Hello world</article> `, container);
+    const elem = document.getElementById('foo');
+    expect(allowsNameFromContent(elem!, getDefaultContext())).toBe(false);
+  });
 });

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -158,7 +158,7 @@ describe('The computeTextAlternative function', () => {
     expect(computeTextAlternative(elem).name).toBe('Flash the screen 2 times.');
   });
 
-  // http://wpt.live/accname/name_file-label-owned-combobox-owned-listbox-manual.html
+  // http://wpt.live/accname/name_checkbox-label-embedded-menu-manual.html
   it('allows aria-owned nodes to be chained together across multiple nodes', () => {
     render(
       html`

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -157,4 +157,25 @@ describe('The computeTextAlternative function', () => {
     const elem = document.getElementById('test')!;
     expect(computeTextAlternative(elem).name).toBe('Flash the screen 2 times.');
   });
+
+  // http://wpt.live/accname/name_file-label-owned-combobox-owned-listbox-manual.html
+  it('allows aria-owned nodes to be chained together across multiple nodes', () => {
+    render(
+      html`
+        <input type="checkbox" id="test" />
+        <label for="test"
+          >Flash the screen
+          <span role="menu">
+            <span role="menuitem" aria-selected="true">1</span>
+            <span role="menuitem" hidden="">2</span>
+            <span role="menuitem" hidden="">3</span>
+          </span>
+          times.
+        </label>
+      `,
+      container
+    );
+    const elem = document.getElementById('test')!;
+    expect(computeTextAlternative(elem).name).toBe('Flash the screen times.');
+  });
 });

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -159,7 +159,7 @@ describe('The computeTextAlternative function', () => {
   });
 
   // http://wpt.live/accname/name_checkbox-label-embedded-menu-manual.html
-  it('allows aria-owned nodes to be chained together across multiple nodes', () => {
+  it('ignores elements who should never allow name from content, in this case role="menuitem"', () => {
     render(
       html`
         <input type="checkbox" id="test" />

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -2,63 +2,146 @@ import {Context, getDefaultContext} from './context';
 import {computeTextAlternative} from './compute_text_alternative';
 import {closest} from './polyfill';
 
-// Explicit roles allowing 'name from content'
-// (https://www.w3.org/TR/wai-aria-1.1/#namefromcontent)
-const NAME_FROM_CONTENT_ROLES = [
-  'button',
-  'cell',
-  'checkbox',
-  'columnheader',
-  'gridcell',
-  'heading',
-  'link',
-  'menuitem',
-  'menuitemcheckbox',
-  'menuitemradio',
-  'option',
-  'radio',
-  'row',
-  'rowgroup',
-  'rowheader',
-  'switch',
-  'tab',
-  'tooltip',
-  'tree',
-  'treeitem',
-];
+const ALWAYS_NAME_FROM_CONTENT = {
+  // Explicit roles allowing 'name from content'
+  // (https://www.w3.org/TR/wai-aria-1.1/#namefromcontent)
+  roles: [
+    'button',
+    'cell',
+    'checkbox',
+    'columnheader',
+    'gridcell',
+    'heading',
+    'link',
+    'menuitem',
+    'menuitemcheckbox',
+    'menuitemradio',
+    'option',
+    'radio',
+    'row',
+    'rowgroup',
+    'rowheader',
+    'switch',
+    'tab',
+    'tooltip',
+    'tree',
+    'treeitem',
+  ],
+  // HTML element types that allow name from content according
+  // to their implicit aria roles.
+  // (https://www.w3.org/TR/html-aria/#docconformance)
+  tags: [
+    'button',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'summary',
+    'tbody',
+    'tfoot',
+    'thead',
+  ],
+};
 
-/**
- * HTML element types that allow name from content according
- * to their implicit aria roles.
- * (https://www.w3.org/TR/html-aria/#docconformance)
- */
-const NAME_FROM_CONTENT_TAGS = [
-  'h1',
-  'h2',
-  'h3',
-  'h4',
-  'h5',
-  'h6',
-  'tbody',
-  'thead',
-  'tfoot',
-  'summary',
-  'button',
-];
+// See https://lists.w3.org/Archives/Public/public-aria/2017Jun/0057.html
+// for discussion of roles & tags that forbid name from content.
+//
+// *This case is not explicitly included in version 1.1 of the spec, however,
+// as per the thread linked above we have included it (as have other implementations).
+const NEVER_NAME_FROM_CONTENT = {
+  roles: [
+    'alert',
+    'alertdialog',
+    'application',
+    'article',
+    'banner',
+    'complementary',
+    'contentinfo',
+    'definition',
+    'dialog',
+    'directory',
+    'document',
+    'feed',
+    'figure',
+    'form',
+    'grid',
+    'group',
+    'img',
+    'list',
+    'listbox',
+    'log',
+    'main',
+    'marquee',
+    'math',
+    'menu',
+    'menubar',
+    'navigation',
+    'note',
+    'radiogroup',
+    'region',
+    'row',
+    'rowgroup',
+    'scrollbar',
+    'search',
+    'searchbox',
+    'separator',
+    'slider',
+    'spinbutton',
+    'status',
+    'table',
+    'tablist',
+    'tabpanel',
+    'term',
+    'textbox',
+    'timer',
+    'toolbar',
+    'tree',
+    'treegrid',
+  ],
+  tags: [
+    'article',
+    'aside',
+    'body',
+    'datalist',
+    'dialog',
+    'fieldset',
+    'figure',
+    'footer',
+    'form',
+    'header',
+    'hr',
+    'img',
+    'input',
+    'main',
+    'math',
+    'menu',
+    'nav',
+    'optgroup',
+    'section',
+    'select',
+    'tbody',
+    'textarea',
+    'tfoot',
+    'thead',
+  ],
+};
 
-/**
- * HTML input elements allow name from content when
- * they have the following values for 'type' attribute
- * (https://www.w3.org/TR/html-aria/#docconformance)
- */
-const NAME_FROM_CONTENT_INPUT_TYPES = [
-  'button',
-  'checkbox',
-  'image',
-  'radio',
-  'reset',
-  'submit',
-];
+// List 3 from https://lists.w3.org/Archives/Public/public-aria/2017Jun/0057.html
+const SOMETIMES_NAME_FROM_CONTENT = {
+  roles: [
+    'contentinfo',
+    'definition',
+    'directory',
+    'list',
+    'note',
+    'status',
+    'table',
+    'term',
+  ],
+  tags: ['dd', 'details', 'dl', 'ol', 'output', 'table', 'ul'],
+};
 
 /**
  * Some HTML elements allow name from context only if certain
@@ -86,11 +169,6 @@ function getFunctionCalculatingAllowsNameFromContent(
       return (elem: HTMLElement) => {
         return closest(elem, 'select,datalist') !== null;
       };
-    case 'input':
-      return (elem: HTMLElement) => {
-        const inputType = elem.getAttribute('type')?.trim().toLowerCase() ?? '';
-        return NAME_FROM_CONTENT_INPUT_TYPES.includes(inputType);
-      };
     case 'a':
       return (elem: HTMLElement) => {
         return elem.hasAttribute('href');
@@ -109,121 +187,29 @@ function getFunctionCalculatingAllowsNameFromContent(
 }
 
 /**
- * Calculates whether or not an element's name may be calculated using
- * its contents. Elements may allow name from content when they have certain
- * roles, be they explicit (role attribute) or implicit (semantic HTML).
- * @param elem - the function checks if 'elem' allows name from content
- * @return - true if elem allows name from content, false otherwise
+ * A container for lists of roles (explicit) and tags (implicit) that
+ * together account for a certain genre / type of role.
  */
-function roleAllowsNameFromContent(elem: HTMLElement): boolean {
-  const explicitRole = elem.getAttribute('role')?.trim().toLowerCase() ?? '';
-  if (NAME_FROM_CONTENT_ROLES.includes(explicitRole)) {
-    return true;
-  }
-
-  const elemNodeName = elem.nodeName.toLowerCase();
-  if (NAME_FROM_CONTENT_TAGS.includes(elemNodeName)) {
-    return true;
-  }
-
-  const nameFromContentFunction = getFunctionCalculatingAllowsNameFromContent(
-    elemNodeName
-  );
-  if (nameFromContentFunction) {
-    return nameFromContentFunction(elem);
-  }
-
-  return false;
+interface RoleType {
+  roles: string[];
+  tags: string[];
 }
 
-export const TEST_ONLY = {roleAllowsNameFromContent};
-
-// See https://lists.w3.org/Archives/Public/public-aria/2017Jun/0057.html
-// for discussion of roles & tags that forbid name from content.
-//
-// *This case is not explicitly included in version 1.1 of the spec, however,
-// as per the thread linked above we have included it (as have other implementations).
-const NEVER_NAME_FROM_CONTENT_ROLES = [
-  'application',
-  'alert',
-  'log',
-  'marquee',
-  'timer',
-  'alertdialog',
-  'dialog',
-  'banner',
-  'complementary',
-  'form',
-  'main',
-  'navigation',
-  'region',
-  'search',
-  'article',
-  'document',
-  'feed',
-  'figure',
-  'img',
-  'math',
-  'toolbar',
-  'menu',
-  'menubar',
-  'grid',
-  'listbox',
-  'radiogroup',
-  'textbox',
-  'searchbox',
-  'spinbutton',
-  'scrollbar',
-  'slider',
-  'tablist',
-  'tabpanel',
-  'tree',
-  'treegrid',
-  'separator',
-  'rowgroup',
-  'group',
-];
-// These tag names imply roles that forbid name from content.
-const NEVER_NAME_FROM_CONTENT_TAGS = [
-  'article',
-  'aside',
-  'body',
-  'select',
-  'datalist',
-  'optgroup',
-  'dialog',
-  'figure',
-  'footer',
-  'form',
-  'header',
-  'hr',
-  'img',
-  'textarea',
-  'input',
-  'main',
-  'math',
-  'menu',
-  'nav',
-  'section',
-  'thead',
-  'tbody',
-  'tfoot',
-  'fieldset',
-];
-
 /**
- * Checks if 'elem' is forbidden from allowing 'name from content'
- * @param elem - element whose text alternative is being computed
+ * Checks if a given HTMLElement matches any of the roles in a given RoleType.
+ * @param elem - element whose role type is in question.
+ * @param roleType - lists of indicators for some role type.
  */
-function roleForbidsNameFromContent(elem: HTMLElement): boolean {
+function matchesRole(elem: HTMLElement, roleType: RoleType): boolean {
+  // Explicit roles : specified using 'role' attribute
   const explicitRole = elem.getAttribute('role')?.trim().toLowerCase() ?? '';
-  if (NEVER_NAME_FROM_CONTENT_ROLES.includes(explicitRole)) {
+  if (roleType.roles.includes(explicitRole)) {
     return true;
   }
 
   // Implicit roles : implied by current node tag name.
   const elemNodeName = elem.nodeName.toLowerCase();
-  if (NEVER_NAME_FROM_CONTENT_TAGS.includes(elemNodeName)) {
+  if (roleType.tags.includes(elemNodeName)) {
     return true;
   }
 
@@ -239,11 +225,42 @@ function roleForbidsNameFromContent(elem: HTMLElement): boolean {
  * @return - whether or not rule 2Fs condition has been satisfied
  */
 function allowsNameFromContent(elem: HTMLElement, context: Context): boolean {
-  if (roleForbidsNameFromContent(elem)) {
+  // focasable elements should allow name from content.
+  if (elem.hasAttribute('tabindex')) {
+    return true;
+  }
+
+  // The terms 'list 1', 'list 2', 'list 3' are used in reference
+  // to the following thread: see: https://lists.w3.org/Archives/Public/public-aria/2017Jun/0057.html
+
+  // Handles list 3 roles
+  if (context.inherited.partOfName && elem.parentElement) {
+    const parent = elem.parentElement;
+    if (
+      matchesRole(parent, ALWAYS_NAME_FROM_CONTENT) &&
+      matchesRole(elem, SOMETIMES_NAME_FROM_CONTENT)
+    ) {
+      return true;
+    }
+  }
+
+  // Handles list 2 roles
+  if (matchesRole(elem, NEVER_NAME_FROM_CONTENT)) {
     return false;
   }
 
-  if (roleAllowsNameFromContent(elem)) {
+  // Handles list 1 roles
+  if (matchesRole(elem, ALWAYS_NAME_FROM_CONTENT)) {
+    return true;
+  }
+
+  // Elements that conditionally have an implicit role that matches
+  // ALWAYS_NAME_FROM_CONTENT
+  const elemNodeName = elem.nodeName.toLowerCase();
+  const nameFromContentFunction = getFunctionCalculatingAllowsNameFromContent(
+    elemNodeName
+  );
+  if (nameFromContentFunction && nameFromContentFunction(elem)) {
     return true;
   }
 
@@ -257,6 +274,8 @@ function allowsNameFromContent(elem: HTMLElement, context: Context): boolean {
 
   return false;
 }
+
+export const TEST_ONLY = {allowsNameFromContent};
 
 /**
  * Gets text content generated by CSS pseudo elements for a given HTMLElement

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -225,14 +225,6 @@ function matchesRole(elem: HTMLElement, roleType: RoleType): boolean {
  * @return - whether or not rule 2Fs condition has been satisfied
  */
 function allowsNameFromContent(elem: HTMLElement, context: Context): boolean {
-  // focusable elements should allow name from content.
-  if (
-    matchesRole(elem, NEVER_NAME_FROM_CONTENT) &&
-    elem.hasAttribute('tabindex')
-  ) {
-    return true;
-  }
-
   // The terms 'list 1', 'list 2', 'list 3' are used in reference
   // to the following thread: see: https://lists.w3.org/Archives/Public/public-aria/2017Jun/0057.html
 
@@ -249,7 +241,7 @@ function allowsNameFromContent(elem: HTMLElement, context: Context): boolean {
 
   // Handles list 2 roles
   if (matchesRole(elem, NEVER_NAME_FROM_CONTENT)) {
-    return false;
+    return elem.hasAttribute('tabindex');
   }
 
   // Handles list 1 roles

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -225,7 +225,7 @@ function matchesRole(elem: HTMLElement, roleType: RoleType): boolean {
  * @return - whether or not rule 2Fs condition has been satisfied
  */
 function allowsNameFromContent(elem: HTMLElement, context: Context): boolean {
-  // focasable elements should allow name from content.
+  // focusable elements should allow name from content.
   if (
     matchesRole(elem, NEVER_NAME_FROM_CONTENT) &&
     elem.hasAttribute('tabindex')

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -32,7 +32,7 @@ const NAME_FROM_CONTENT_ROLES = [
  * to their implicit aria roles.
  * (https://www.w3.org/TR/html-aria/#docconformance)
  */
-const NAME_FROM_CONTENT_ELEM_NODE_NAME = [
+const NAME_FROM_CONTENT_TAGS = [
   'h1',
   'h2',
   'h3',
@@ -122,7 +122,7 @@ function allowsNameFromContent(elem: HTMLElement): boolean {
   }
 
   const elemNodeName = elem.nodeName.toLowerCase();
-  if (NAME_FROM_CONTENT_ELEM_NODE_NAME.includes(elemNodeName)) {
+  if (NAME_FROM_CONTENT_TAGS.includes(elemNodeName)) {
     return true;
   }
 
@@ -138,6 +138,93 @@ function allowsNameFromContent(elem: HTMLElement): boolean {
 
 export const TEST_ONLY = {allowsNameFromContent};
 
+// See https://lists.w3.org/Archives/Public/public-aria/2017Jun/0057.html
+// for discussion of roles & tags that forbid name from content.
+const NO_NAME_FROM_CONTENT_ROLES = [
+  'application',
+  'alert',
+  'log',
+  'marquee',
+  'timer',
+  'alertdialog',
+  'dialog',
+  'banner',
+  'complementary',
+  'form',
+  'main',
+  'navigation',
+  'region',
+  'search',
+  'article',
+  'document',
+  'feed',
+  'figure',
+  'img',
+  'math',
+  'toolbar',
+  'menu',
+  'menubar',
+  'grid',
+  'listbox',
+  'radiogroup',
+  'textbox',
+  'searchbox',
+  'spinbutton',
+  'scrollbar',
+  'slider',
+  'tablist',
+  'tabpanel',
+  'tree',
+  'treegrid',
+  'separator',
+  'rowgroup',
+  'group',
+];
+const NO_NAME_FROM_CONTENT_TAGS = [
+  'article',
+  'aside',
+  'body',
+  'select',
+  'datalist',
+  'optgroup',
+  'dialog',
+  'figure',
+  'footer',
+  'form',
+  'header',
+  'hr',
+  'img',
+  'textarea',
+  'input',
+  'main',
+  'math',
+  'menu',
+  'nav',
+  'section',
+  'thead',
+  'tbody',
+  'tfoot',
+  'fieldset',
+];
+
+/**
+ * Checks if 'elem' is forbidden from allowing 'name from content'
+ * @param elem - element whose text alternative is being computed
+ */
+function forbidsNameFromContent(elem: HTMLElement): boolean {
+  const explicitRole = elem.getAttribute('role')?.trim().toLowerCase() ?? '';
+  if (NO_NAME_FROM_CONTENT_ROLES.includes(explicitRole)) {
+    return true;
+  }
+
+  const elemNodeName = elem.nodeName.toLowerCase();
+  if (NO_NAME_FROM_CONTENT_TAGS.includes(elemNodeName)) {
+    return true;
+  }
+
+  return false;
+}
+
 /**
  * Checks if 'elem' in with 'context' satisfies the conditions
  * necessary to apply rule 2F.
@@ -146,6 +233,10 @@ export const TEST_ONLY = {allowsNameFromContent};
  * @return - whether or not rule 2Fs condition has been satisfied
  */
 function rule2FCondition(elem: HTMLElement, context: Context): boolean {
+  if (forbidsNameFromContent(elem)) {
+    return false;
+  }
+
   if (allowsNameFromContent(elem)) {
     return true;
   }

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -226,7 +226,10 @@ function matchesRole(elem: HTMLElement, roleType: RoleType): boolean {
  */
 function allowsNameFromContent(elem: HTMLElement, context: Context): boolean {
   // focasable elements should allow name from content.
-  if (elem.hasAttribute('tabindex')) {
+  if (
+    matchesRole(elem, NEVER_NAME_FROM_CONTENT) &&
+    elem.hasAttribute('tabindex')
+  ) {
     return true;
   }
 


### PR DESCRIPTION
- Added a check for nodes that _forbid name from content_ to step 2F.
- Added a test ([an accname WPT](http://wpt.live/accname/name_checkbox-label-embedded-menu-manual.html)) for this.

Closes #50 

- Some exceptions to this rule to be added soon. See the list 'lst3' in this thread:
https://lists.w3.org/Archives/Public/public-aria/2017Jun/0057.html for more detail.