### PR TITLE
Updated 'name from content' conditions for better WPT performance

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -578,10 +578,7 @@ var accname = (function (exports) {
             'optgroup',
             'section',
             'select',
-            'tbody',
             'textarea',
-            'tfoot',
-            'thead',
         ],
     };
     // List 3 from https://lists.w3.org/Archives/Public/public-aria/2017Jun/0057.html
@@ -668,6 +665,7 @@ var accname = (function (exports) {
     function allowsNameFromContent(elem, context) {
         // The terms 'list 1', 'list 2', 'list 3' are used in reference
         // to the following thread: see: https://lists.w3.org/Archives/Public/public-aria/2017Jun/0057.html
+        var _a;
         // Handles list 3 roles
         if (context.inherited.partOfName && elem.parentElement) {
             const parent = elem.parentElement;
@@ -678,7 +676,12 @@ var accname = (function (exports) {
         }
         // Handles list 2 roles
         if (matchesRole(elem, NEVER_NAME_FROM_CONTENT)) {
-            return elem.hasAttribute('tabindex');
+            // role=menu should not allow name from content even if focusable.
+            // See http://wpt.live/accname/name_test_case_733-manual.html
+            if (((_a = elem.getAttribute('role')) === null || _a === void 0 ? void 0 : _a.toLowerCase()) === 'menu') {
+                return false;
+            }
+            return elem.hasAttribute('tabindex') || elem.isContentEditable;
         }
         // Handles list 1 roles
         if (matchesRole(elem, ALWAYS_NAME_FROM_CONTENT)) {

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -159,7 +159,7 @@ describe('The computeTextAlternative function', () => {
   });
 
   // http://wpt.live/accname/name_checkbox-label-embedded-menu-manual.html
-  it('ignores elements who should never allow name from content, in this case role="menuitem"', () => {
+  it('ignores elements who should never allow name from content, in this case role="menu"', () => {
     render(
       html`
         <input type="checkbox" id="test" />
@@ -177,5 +177,67 @@ describe('The computeTextAlternative function', () => {
     );
     const elem = document.getElementById('test')!;
     expect(computeTextAlternative(elem).name).toBe('Flash the screen times.');
+  });
+
+  // http://wpt.live/accname/name_test_case_733-manual.html
+  it('Does not allow name from content for role=menu even if focusable', () => {
+    render(
+      html`
+        <label for="test">
+          crazy
+          <select name="member" size="1" role="menu" tabindex="0">
+            <option role="menuitem" value="beard" selected="true">clown</option>
+            <option role="menuitem" value="scuba">rich</option>
+          </select>
+        </label>
+        <input type="password" id="test" />
+      `,
+      container
+    );
+    const elem = document.getElementById('test')!;
+    expect(computeTextAlternative(elem).name).toBe('crazy');
+  });
+
+  // http://wpt.live/accname/name_from_content-manual.html
+  it('Allows name from content for <tbody>', () => {
+    render(
+      html`
+        <style>
+          .hidden {
+            display: none;
+          }
+        </style>
+        <div id="test" role="link" tabindex="0">
+          <span aria-hidden="true"><i> Hello, </i></span>
+          <span>My</span> name is
+          <div>
+            <img src="file.jpg" title="Bryan" alt="" role="presentation" />
+          </div>
+          <span role="presentation" aria-label="Eli">
+            <span aria-label="Garaventa">Zambino</span>
+          </span>
+          <span>the weird.</span>
+          (QED)
+          <span class="hidden"
+            ><i><b>and don't you forget it.</b></i></span
+          >
+          <table>
+            <tbody>
+              <tr>
+                <td>Where</td>
+                <td style="visibility:hidden;"><div>in</div></td>
+                <td><div style="display:none;">the world</div></td>
+                <td>are my marbles?</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      `,
+      container
+    );
+    const elem = document.getElementById('test')!;
+    expect(computeTextAlternative(elem).name).toBe(
+      'My name is Eli the weird. (QED) Where are my marbles?'
+    );
   });
 });

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -121,10 +121,7 @@ const NEVER_NAME_FROM_CONTENT = {
     'optgroup',
     'section',
     'select',
-    'tbody',
     'textarea',
-    'tfoot',
-    'thead',
   ],
 };
 
@@ -241,7 +238,12 @@ function allowsNameFromContent(elem: HTMLElement, context: Context): boolean {
 
   // Handles list 2 roles
   if (matchesRole(elem, NEVER_NAME_FROM_CONTENT)) {
-    return elem.hasAttribute('tabindex');
+    // role=menu should not allow name from content even if focusable.
+    // See http://wpt.live/accname/name_test_case_733-manual.html
+    if (elem.getAttribute('role')?.toLowerCase() === 'menu') {
+      return false;
+    }
+    return elem.hasAttribute('tabindex') || elem.isContentEditable;
   }
 
   // Handles list 1 roles


### PR DESCRIPTION
- Added more WPTs as unit tests.
- Removed `tbody` `thead` `tfoot` from `NEVER_NAME_FROM_CONTENT` tags as they are already in `ALWAYS_NAME_FROM_CONTENT` tags and should allow name from content according to the following WPT: http://wpt.live/accname/name_from_content-manual.html
- Added explicit check to ensure that `role=menu` never allows name from content, even if it is focusable. This is indicated by many WPTs, such as http://wpt.live/accname/name_test_case_733-manual.html
