### PR TITLE
URL Comparison: Better Error Handling 

### DIFF
--- a/validation/src/lib/compare.ts
+++ b/validation/src/lib/compare.ts
@@ -82,23 +82,31 @@ export async function runURLComparison(url: string): Promise<number> {
       node
     );
 
-    const targetNodeRef = await getNodeRefFromSelector(
-      '[accnameComparisonTarget]',
-      client,
-      page
-    );
+    try {
+      const targetNodeRef = await getNodeRefFromSelector(
+        '[accnameComparisonTarget]',
+        client,
+        page
+      );
 
-    const comparisonResults = await runComparison(targetNodeRef, page, client);
-    if (comparisonResults.disagrees) {
-      // Count category occurrences, save test case for any new categories.
-      const categoryHash = JSON.stringify(comparisonResults.category);
-      if (categoryCount[categoryHash]) {
-        categoryCount[categoryHash] += 1;
-      } else {
-        const casePreview = writeTestcase(comparisonResults, {url: url});
-        cases.push(casePreview.caseId);
-        categoryCount[categoryHash] = 1;
+      const comparisonResults = await runComparison(
+        targetNodeRef,
+        page,
+        client
+      );
+      if (comparisonResults.disagrees) {
+        // Count category occurrences, save test case for any new categories.
+        const categoryHash = JSON.stringify(comparisonResults.category);
+        if (categoryCount[categoryHash]) {
+          categoryCount[categoryHash] += 1;
+        } else {
+          const casePreview = writeTestcase(comparisonResults, {url: url});
+          cases.push(casePreview.caseId);
+          categoryCount[categoryHash] = 1;
+        }
       }
+    } catch (error) {
+      console.log(`Skipped node due to error:\n${error}`);
     }
 
     await page.evaluate(

--- a/validation/src/lib/compare.ts
+++ b/validation/src/lib/compare.ts
@@ -82,31 +82,48 @@ export async function runURLComparison(url: string): Promise<number> {
       node
     );
 
-    try {
-      const targetNodeRef = await getNodeRefFromSelector(
-        '[accnameComparisonTarget]',
-        client,
-        page
-      );
+    let successfullyCompared = false;
+    let comparisonAttempts = 0;
+    while (!successfullyCompared && comparisonAttempts < 3) {
+      try {
+        const targetNodeRef = await getNodeRefFromSelector(
+          '[accnameComparisonTarget]',
+          client,
+          page
+        );
 
-      const comparisonResults = await runComparison(
-        targetNodeRef,
-        page,
-        client
-      );
-      if (comparisonResults.disagrees) {
-        // Count category occurrences, save test case for any new categories.
-        const categoryHash = JSON.stringify(comparisonResults.category);
-        if (categoryCount[categoryHash]) {
-          categoryCount[categoryHash] += 1;
-        } else {
-          const casePreview = writeTestcase(comparisonResults, {url: url});
-          cases.push(casePreview.caseId);
-          categoryCount[categoryHash] = 1;
+        const comparisonResults = await runComparison(
+          targetNodeRef,
+          page,
+          client
+        );
+        if (comparisonResults.disagrees) {
+          // Count category occurrences, save test case for any new categories.
+          const categoryHash = JSON.stringify(comparisonResults.category);
+          if (categoryCount[categoryHash]) {
+            categoryCount[categoryHash] += 1;
+          } else {
+            const casePreview = writeTestcase(comparisonResults, {url: url});
+            cases.push(casePreview.caseId);
+            categoryCount[categoryHash] = 1;
+          }
         }
+        successfullyCompared = true;
+      } catch (error) {
+        ++comparisonAttempts;
+        console.log(
+          `Error: ${error}, ${comparisonAttempts} attempts made, trying again.\n`
+        );
       }
-    } catch (error) {
-      console.log(`Skipped node due to error:\n${error}`);
+    }
+    if (!successfullyCompared) {
+      const skippedNodeOuterHTML = await page.evaluate(
+        node => node.outerHTML,
+        node
+      );
+      console.log(
+        `Skipping node comparison for node with the following outerHTML after ${comparisonAttempts} attempts:\n\n${skippedNodeOuterHTML}\n`
+      );
     }
 
     await page.evaluate(


### PR DESCRIPTION
- App now tries to perform a comparison 3 times before skipping.
- Outputs informative error messages in those cases where a node is skipped:
![image](https://user-images.githubusercontent.com/34962541/92718213-6f1c8380-f359-11ea-9b50-2695b27e183a.png)
