### PR TITLE
Whitespace Handling

### DIFF
--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -244,16 +244,10 @@ describe('The computeTextAlternative function', () => {
   // http://wpt.live/accname/name_file-label-inline-block-elements-manual.html
   it('passes WPT testing whitespace', () => {
     render(
+      // prettier-ignore
       html`
-        <input type="file" id="test" />
-        <label for="test"
-          >W<i>h<b>a</b></i
-          >t<br />is
-          <div>
-            your
-            <div>name<b>?</b></div>
-          </div></label
-        >
+        <input type="file" id="test">
+        <label for="test">W<i>h<b>a</b></i>t<br>is<div>your<div>name<b>?</b></div></div></label>    
       `,
       container
     );

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -240,4 +240,44 @@ describe('The computeTextAlternative function', () => {
       'My name is Eli the weird. (QED) Where are my marbles?'
     );
   });
+
+  // http://wpt.live/accname/name_file-label-inline-block-elements-manual.html
+  it('passes WPT testing whitespace', () => {
+    render(
+      html`
+        <input type="file" id="test" />
+        <label for="test"
+          >W<i>h<b>a</b></i
+          >t<br />is
+          <div>
+            your
+            <div>name<b>?</b></div>
+          </div></label
+        >
+      `,
+      container
+    );
+    const elem = document.getElementById('test')!;
+    expect(computeTextAlternative(elem).name).toBe('What is your name?');
+  });
+
+  it('doesnt add whitespace between inline elements (span in this case)', () => {
+    render(html` <h1 id="test"><span>E</span><span>E</span></h1> `, container);
+    const elem = document.getElementById('test')!;
+    expect(computeTextAlternative(elem).name).toBe('EE');
+  });
+
+  it('does add whitespace if inline elements are on different lines', () => {
+    render(
+      html`
+        <h1 id="test">
+          <span>E</span>
+          <span>E</span>
+        </h1>
+      `,
+      container
+    );
+    const elem = document.getElementById('test')!;
+    expect(computeTextAlternative(elem).name).toBe('E E');
+  });
 });

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -283,8 +283,9 @@ export const TEST_ONLY = {allowsNameFromContent};
  * empty string otherwise.
  */
 function getCssContent(elem: HTMLElement, pseudoElementName: string): string {
-  const cssContent: string = window.getComputedStyle(elem, pseudoElementName)
-    .content;
+  const computedStyle = window.getComputedStyle(elem, pseudoElementName);
+  const cssContent: string = computedStyle.content;
+  const isBlockDisplay = computedStyle.display === 'block';
   // <string> CSS content identified by surrounding quotes
   // see: https://developer.mozilla.org/en-US/docs/Web/CSS/content
   // and: https://developer.mozilla.org/en-US/docs/Web/CSS/string
@@ -292,7 +293,9 @@ function getCssContent(elem: HTMLElement, pseudoElementName: string): string {
     (cssContent[0] === '"' && cssContent[cssContent.length - 1] === '"') ||
     (cssContent[0] === "'" && cssContent[cssContent.length - 1] === "'")
   ) {
-    return cssContent.slice(1, -1);
+    return isBlockDisplay
+      ? ' ' + cssContent.slice(1, -1) + ' '
+      : cssContent.slice(1, -1);
   }
   return '';
 }

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -297,6 +297,63 @@ function getCssContent(elem: HTMLElement, pseudoElementName: string): string {
   return '';
 }
 
+// See https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
+// 'br' removed as it should add a whitespace to the accessible name.
+const inlineTags = [
+  'a',
+  'abbr',
+  'acronym',
+  'b',
+  'bdi',
+  'bdo',
+  'big',
+  'button',
+  'canvas',
+  'cite',
+  'code',
+  'data',
+  'datalist',
+  'del',
+  'dfn',
+  'em',
+  'embed',
+  'i',
+  'iframe',
+  'img',
+  'input',
+  'ins',
+  'kbd',
+  'label',
+  'map',
+  'mark',
+  'meter',
+  'noscript',
+  'object',
+  'output',
+  'picture',
+  'progress',
+  'q',
+  'ruby',
+  's',
+  'samp',
+  'script',
+  'select',
+  'slot',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'template',
+  'textarea',
+  'time',
+  'tt',
+  'u',
+  'var',
+  'video',
+  'wbr',
+];
+
 /**
  * Implementation of rule 2F
  * @param node - node whose text alternative is being calculated
@@ -342,7 +399,14 @@ export function rule2F(
         inherited: context.inherited,
       }).name;
 
-      textAlterantives.push(textAlterantive);
+      if (
+        inlineTags.includes(childNode.nodeName.toLowerCase()) ||
+        childNode.nodeType === Node.TEXT_NODE
+      ) {
+        textAlterantives.push(textAlterantive);
+      } else {
+        textAlterantives.push(` ${textAlterantive} `);
+      }
     }
   }
 
@@ -352,7 +416,9 @@ export function rule2F(
   // for readability
   const accumulatedText = textAlterantives
     .filter(textAlterantive => textAlterantive !== '')
-    .join(' ');
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
 
   const cssBeforeContent = getCssContent(node, ':before');
   const cssAfterContent = getCssContent(node, ':after');

--- a/src/lib/rule2F_test.ts
+++ b/src/lib/rule2F_test.ts
@@ -70,6 +70,28 @@ describe('The function for rule 2F', () => {
     expect(rule2F(elem!, context)).toBe('Helloworld!');
   });
 
+  it('returns a string concatenated with CSS generated text content', () => {
+    render(
+      html`
+        <style>
+          #foo:before {
+            content: 'Hello';
+            display: block;
+          }
+          #foo:after {
+            content: '!';
+          }
+        </style>
+        <div id="foo">world</div>
+      `,
+      container
+    );
+    const elem = document.getElementById('foo');
+    const context = getDefaultContext();
+    context.directLabelReference = true;
+    expect(rule2F(elem!, context)).toBe('Hello world!');
+  });
+
   it("doesn't include non-textual CSS content", () => {
     render(
       html`

--- a/src/lib/rule2F_test.ts
+++ b/src/lib/rule2F_test.ts
@@ -52,19 +52,15 @@ describe('The function for rule 2F', () => {
   it('returns a string concatenated with CSS generated text content', () => {
     render(
       html`
-        <div id="foo">
-          world
-          <div>
-            <style>
-              #foo:before {
-                content: 'Hello';
-              }
-              #foo:after {
-                content: '!';
-              }
-            </style>
-          </div>
-        </div>
+        <style>
+          #foo:before {
+            content: 'Hello';
+          }
+          #foo:after {
+            content: '!';
+          }
+        </style>
+        <div id="foo">world</div>
       `,
       container
     );

--- a/src/lib/rule2G.ts
+++ b/src/lib/rule2G.ts
@@ -9,7 +9,7 @@ export function rule2G(node: Node): string | null {
     // 'Flattening' the string with .replace()
     // #SPEC_ASSUMPTION (G.1) : that the resulting text alternative
     // from 2G should be a flat string.
-    return node.textContent?.replace(/\s\s+/g, ' ').trim() ?? '';
+    return node.textContent?.replace(/\s\s+/g, ' ') ?? '';
   }
   return null;
 }

--- a/src/lib/rule2G_test.ts
+++ b/src/lib/rule2G_test.ts
@@ -13,14 +13,7 @@ describe('The function for rule 2G', () => {
   });
 
   it('returns text content text nodes', () => {
-    render(
-      html`
-        <div id="foo">
-          Hello world
-        </div>
-      `,
-      container
-    );
+    render(html` <div id="foo">Hello world</div> `, container);
     const node = document.getElementById('foo')?.childNodes[0];
     expect(rule2G(node!)).toBe('Hello world');
   });
@@ -29,11 +22,9 @@ describe('The function for rule 2G', () => {
     render(
       // prettier-ignore
       html`
-        <div id="foo">
-          Hello world
+        <div id="foo">Hello world
 
-          newline
-        </div>
+        newline</div>
       `,
       container
     );
@@ -45,9 +36,7 @@ describe('The function for rule 2G', () => {
     render(
       // prettier-ignore
       html`
-        <div id="foo">
-          Hello    world
-        </div>
+        <div id="foo">Hello    world</div>
       `,
       container
     );


### PR DESCRIPTION
- This PR updates how whitespace is handled by `accname`, inspired by [this thread](https://github.com/w3c/accname/issues/16) on the accname spec github repo.
- Also considers the display value for CSS text content.
- This update results in `accname` passing another WPT, namely: http://wpt.live/accname/name_file-label-inline-block-elements-manual.html.

Closes #34 