### PR TITLE
Added handle for SVG elements to step 2D

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -330,6 +330,15 @@ var accname = (function (exports) {
      */
     function rule2D(node, context = getDefaultContext()) {
         var _a;
+        // <title>s define text alternatives for <svg>s
+        // See: https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd
+        if (node instanceof SVGElement) {
+            for (const child of node.childNodes) {
+                if (child instanceof SVGTitleElement) {
+                    return child.textContent;
+                }
+            }
+        }
         if (!(node instanceof HTMLElement)) {
             return null;
         }

--- a/src/lib/rule2D.ts
+++ b/src/lib/rule2D.ts
@@ -13,6 +13,16 @@ export function rule2D(
   node: Node,
   context: Context = getDefaultContext()
 ): string | null {
+  // <title>s define text alternatives for <svg>s
+  // See: https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd
+  if (node instanceof SVGElement) {
+    for (const child of node.childNodes) {
+      if (child instanceof SVGTitleElement) {
+        return child.textContent;
+      }
+    }
+  }
+
   if (!(node instanceof HTMLElement)) {
     return null;
   }

--- a/src/lib/rule2D_test.ts
+++ b/src/lib/rule2D_test.ts
@@ -221,4 +221,10 @@ describe('The function for rule 2D', () => {
     const elem = document.getElementById('foo');
     expect(rule2D(elem!)).toBe(null);
   });
+
+  it('returns the text content of a direct child <title> for <svg> elements', () => {
+    render(html` <svg id="foo"><title>Hello world</title></svg> `, container);
+    const elem = document.getElementById('foo');
+    expect(rule2D(elem!)).toBe('Hello world');
+  });
 });


### PR DESCRIPTION
Closes #39 

- Step 2D now handles `SVGElements`, which are labelled by a direct child `<title>`.

See:
https://www.w3.org/TR/svg-aam-1.0/#mapping_additional_nd
https://svgwg.org/svg2-draft/struct.html#TitleElement