### PR TITLE
Removed <input> from 'inline' list

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -757,7 +757,6 @@ var accname = (function (exports) {
         'i',
         'iframe',
         'img',
-        'input',
         'ins',
         'kbd',
         'label',

--- a/src/lib/compute_text_alternative_test.ts
+++ b/src/lib/compute_text_alternative_test.ts
@@ -247,7 +247,7 @@ describe('The computeTextAlternative function', () => {
       // prettier-ignore
       html`
         <input type="file" id="test">
-        <label for="test">W<i>h<b>a</b></i>t<br>is<div>your<div>name<b>?</b></div></div></label>    
+        <label for="test">W<i>h<b>a</b></i>t<br>is<div>your<div>name<b>?</b></div></div></label>
       `,
       container
     );
@@ -273,5 +273,18 @@ describe('The computeTextAlternative function', () => {
     );
     const elem = document.getElementById('test')!;
     expect(computeTextAlternative(elem).name).toBe('E E');
+  });
+
+  // http://wpt.live/accname/name_test_case_619-manual.html
+  it('does not consider <input> to be inline', () => {
+    render(
+      html`
+        <input type="password" id="test" />
+        <label for="test">foo<input type="text" value="bar" />baz</label>
+      `,
+      container
+    );
+    const elem = document.getElementById('test')!;
+    expect(computeTextAlternative(elem).name).toBe('foo bar baz');
   });
 });

--- a/src/lib/rule2F.ts
+++ b/src/lib/rule2F.ts
@@ -323,7 +323,6 @@ const inlineTags = [
   'i',
   'iframe',
   'img',
-  'input',
   'ins',
   'kbd',
   'label',


### PR DESCRIPTION
- `accname` no longer considers `<input>`s to be `inline` elements as of this PR, specifically in the context of rule 2F. 
- The logic behind this is that `<input>`s can't allow name from contents as they have no descendants, so there shouldn't be cases in which the text alternative for an `<input>` needs to be concatenated to some other text alternatives without a space separating the two.
- This is reflected by our comparison implementations (Chrome, Axe, BG) as well as multiple Web Platform Tests.
- This PR should result in `accname` passing 4 more WPTs!

See:
http://wpt.live/accname/name_test_case_617-manual.html
http://wpt.live/accname/name_test_case_618-manual.html
http://wpt.live/accname/name_test_case_619-manual.html
http://wpt.live/accname/name_test_case_620-manual.html