### PR TITLE
Updated axe-core to 4.0.2

### DIFF
--- a/validation/package-lock.json
+++ b/validation/package-lock.json
@@ -449,9 +449,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.2.tgz",
+      "integrity": "sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA=="
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/validation/package.json
+++ b/validation/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@types/serve-favicon": "^2.5.0",
-    "axe-core": "^3.5.5",
+    "axe-core": "^4.0.2",
     "express": "^4.17.1",
     "node-fetch": "^2.6.1",
     "puppeteer": "^5.2.1",


### PR DESCRIPTION
- Updated to the latest version of axe-core.
- This did not affect Axe's performance on WPTs:
![image](https://user-images.githubusercontent.com/34962541/93467505-b8367f80-f8e5-11ea-99ee-d9c5658f2f09.png)
